### PR TITLE
[WIP] Integration with SQL databases

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,63 @@
+###############################################################################
+# Set default behavior to automatically normalize line endings.
+###############################################################################
+* text=auto
+
+###############################################################################
+# Set default behavior for command prompt diff.
+#
+# This is need for earlier builds of msysgit that does not have it on by
+# default for csharp files.
+# Note: This is only used by command line
+###############################################################################
+#*.cs     diff=csharp
+
+###############################################################################
+# Set the merge driver for project and solution files
+#
+# Merging from the command prompt will add diff markers to the files if there
+# are conflicts (Merging from VS is not affected by the settings below, in VS
+# the diff markers are never inserted). Diff markers may cause the following 
+# file extensions to fail to load in VS. An alternative would be to treat
+# these files as binary and thus will always conflict and require user
+# intervention with every merge. To do so, just uncomment the entries below
+###############################################################################
+#*.sln       merge=binary
+#*.csproj    merge=binary
+#*.vbproj    merge=binary
+#*.vcxproj   merge=binary
+#*.vcproj    merge=binary
+#*.dbproj    merge=binary
+#*.fsproj    merge=binary
+#*.lsproj    merge=binary
+#*.wixproj   merge=binary
+#*.modelproj merge=binary
+#*.sqlproj   merge=binary
+#*.wwaproj   merge=binary
+
+###############################################################################
+# behavior for image files
+#
+# image files are treated as binary by default.
+###############################################################################
+#*.jpg   binary
+#*.png   binary
+#*.gif   binary
+
+###############################################################################
+# diff behavior for common document formats
+# 
+# Convert binary document formats to text before diffing them. This feature
+# is only available from the command line. Turn it on by uncommenting the 
+# entries below.
+###############################################################################
+#*.doc   diff=astextplain
+#*.DOC   diff=astextplain
+#*.docx  diff=astextplain
+#*.DOCX  diff=astextplain
+#*.dot   diff=astextplain
+#*.DOT   diff=astextplain
+#*.pdf   diff=astextplain
+#*.PDF   diff=astextplain
+#*.rtf   diff=astextplain
+#*.RTF   diff=astextplain

--- a/Sql/src/Akka.Streams.Sql.Tests/Akka.Streams.Sql.Tests.csproj
+++ b/Sql/src/Akka.Streams.Sql.Tests/Akka.Streams.Sql.Tests.csproj
@@ -1,0 +1,126 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectGuid>{81C7A17D-6A96-41A1-A8C5-3735CFA3C640}</ProjectGuid>
+    <OutputType>Library</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <RootNamespace>Akka.Streams.Sql.Tests</RootNamespace>
+    <AssemblyName>Akka.Streams.Sql.Tests</AssemblyName>
+    <TargetFrameworkVersion>v4.5.1</TargetFrameworkVersion>
+    <FileAlignment>512</FileAlignment>
+    <TargetFrameworkProfile />
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\Release\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="Akka, Version=1.1.3.31, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\Akka.1.1.3\lib\net45\Akka.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="Akka.Streams, Version=1.1.3.32, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\Akka.Streams.1.1.3.32-beta\lib\net45\Akka.Streams.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="Akka.Streams.TestKit, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\Akka.Streams.TestKit.1.1.3.32-beta\lib\net45\Akka.Streams.TestKit.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="Akka.TestKit, Version=1.1.3.31, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\Akka.TestKit.1.1.3\lib\net45\Akka.TestKit.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="Akka.TestKit.Xunit2, Version=1.1.3.32, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\Akka.TestKit.Xunit2.1.1.3\lib\net45\Akka.TestKit.Xunit2.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="Dapper, Version=1.50.2.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\Dapper.1.50.2\lib\net451\Dapper.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="FluentAssertions, Version=4.19.2.0, Culture=neutral, PublicKeyToken=33f2691a05b67b6a, processorArchitecture=MSIL">
+      <HintPath>..\packages\FluentAssertions.4.19.2\lib\net45\FluentAssertions.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="FluentAssertions.Core, Version=4.19.2.0, Culture=neutral, PublicKeyToken=33f2691a05b67b6a, processorArchitecture=MSIL">
+      <HintPath>..\packages\FluentAssertions.4.19.2\lib\net45\FluentAssertions.Core.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="Newtonsoft.Json, Version=9.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
+      <HintPath>..\packages\Newtonsoft.Json.9.0.1\lib\net45\Newtonsoft.Json.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="Reactive.Streams, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\Reactive.Streams.1.0.0-RC1\lib\portable-net45+netcore45\Reactive.Streams.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="System" />
+    <Reference Include="System.Collections.Immutable, Version=1.1.36.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Collections.Immutable.1.1.36\lib\portable-net45+win8+wp8+wpa81\System.Collections.Immutable.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="System.Core" />
+    <Reference Include="System.Xml.Linq" />
+    <Reference Include="System.Data.DataSetExtensions" />
+    <Reference Include="Microsoft.CSharp" />
+    <Reference Include="System.Data" />
+    <Reference Include="System.Net.Http" />
+    <Reference Include="System.Xml" />
+    <Reference Include="xunit.abstractions, Version=2.0.0.0, Culture=neutral, PublicKeyToken=8d05b1bb7a6fdb6c, processorArchitecture=MSIL">
+      <HintPath>..\packages\xunit.abstractions.2.0.0\lib\net35\xunit.abstractions.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="xunit.assert, Version=2.1.0.3179, Culture=neutral, PublicKeyToken=8d05b1bb7a6fdb6c, processorArchitecture=MSIL">
+      <HintPath>..\packages\xunit.assert.2.1.0\lib\dotnet\xunit.assert.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="xunit.core, Version=2.1.0.3179, Culture=neutral, PublicKeyToken=8d05b1bb7a6fdb6c, processorArchitecture=MSIL">
+      <HintPath>..\packages\xunit.extensibility.core.2.1.0\lib\dotnet\xunit.core.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="xunit.execution.desktop, Version=2.1.0.3179, Culture=neutral, PublicKeyToken=8d05b1bb7a6fdb6c, processorArchitecture=MSIL">
+      <HintPath>..\packages\xunit.extensibility.execution.2.1.0\lib\net45\xunit.execution.desktop.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="DbHelper.cs" />
+    <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="SqlSinkSpec.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="App.config" />
+    <None Include="packages.config" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\Akka.Streams.Sql\Akka.Streams.Sql\Akka.Streams.Sql.csproj">
+      <Project>{763eb487-15af-4bad-a272-5a9aeb95f9f4}</Project>
+      <Name>Akka.Streams.Sql</Name>
+    </ProjectReference>
+  </ItemGroup>
+  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
+       Other similar extension points exist, see Microsoft.Common.targets.
+  <Target Name="BeforeBuild">
+  </Target>
+  <Target Name="AfterBuild">
+  </Target>
+  -->
+</Project>

--- a/Sql/src/Akka.Streams.Sql.Tests/App.config
+++ b/Sql/src/Akka.Streams.Sql.Tests/App.config
@@ -1,0 +1,6 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+<configuration>
+  <connectionStrings>
+    <add name="Default" connectionString="Server=.;Database=StreamsTest;Trusted_Connection=True;" providerName="System.Data.SqlClient"/>
+  </connectionStrings>
+</configuration>

--- a/Sql/src/Akka.Streams.Sql.Tests/DbHelper.cs
+++ b/Sql/src/Akka.Streams.Sql.Tests/DbHelper.cs
@@ -1,0 +1,33 @@
+﻿using System.Data.SqlClient;
+
+namespace Akka.Streams.Sql.Tests
+{
+    public static class DbHelper
+    {
+        public static readonly string ConnectionString = "Server=.;Database=StreamsTest;Trusted_Connection=True;";
+        public static void InitDb()
+        {
+            using (var conn = new SqlConnection(ConnectionString))
+            using (var command = conn.CreateCommand())
+            {
+                conn.Open();
+
+                command.CommandText = @"CREATE TABLE People (Id INT PRIMARY KEY, Name NVARCHAR(100) NOT NULL)";
+                command.ExecuteNonQuery();
+            }
+        }
+
+        public static void Cleanup()
+        {
+            using (var conn = new SqlConnection(ConnectionString))
+            using (var command = conn.CreateCommand())
+            {
+                conn.Open();
+
+                command.CommandText = @"DROP TABLE People";
+                command.ExecuteNonQuery();
+            }
+        }
+
+    }
+}

--- a/Sql/src/Akka.Streams.Sql.Tests/Properties/AssemblyInfo.cs
+++ b/Sql/src/Akka.Streams.Sql.Tests/Properties/AssemblyInfo.cs
@@ -1,0 +1,36 @@
+﻿using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+// General Information about an assembly is controlled through the following 
+// set of attributes. Change these attribute values to modify the information
+// associated with an assembly.
+[assembly: AssemblyTitle("Akka.Streams.Sql.Tests")]
+[assembly: AssemblyDescription("")]
+[assembly: AssemblyConfiguration("")]
+[assembly: AssemblyCompany("")]
+[assembly: AssemblyProduct("Akka.Streams.Sql.Tests")]
+[assembly: AssemblyCopyright("Copyright ©  2017")]
+[assembly: AssemblyTrademark("")]
+[assembly: AssemblyCulture("")]
+
+// Setting ComVisible to false makes the types in this assembly not visible 
+// to COM components.  If you need to access a type in this assembly from 
+// COM, set the ComVisible attribute to true on that type.
+[assembly: ComVisible(false)]
+
+// The following GUID is for the ID of the typelib if this project is exposed to COM
+[assembly: Guid("81c7a17d-6a96-41a1-a8c5-3735cfa3c640")]
+
+// Version information for an assembly consists of the following four values:
+//
+//      Major Version
+//      Minor Version 
+//      Build Number
+//      Revision
+//
+// You can specify all the values or you can default the Build and Revision Numbers 
+// by using the '*' as shown below:
+// [assembly: AssemblyVersion("1.0.*")]
+[assembly: AssemblyVersion("1.0.0.0")]
+[assembly: AssemblyFileVersion("1.0.0.0")]

--- a/Sql/src/Akka.Streams.Sql.Tests/SqlSinkSpec.cs
+++ b/Sql/src/Akka.Streams.Sql.Tests/SqlSinkSpec.cs
@@ -1,0 +1,103 @@
+﻿using System;
+using System.Collections.Immutable;
+using System.Data.Common;
+using System.Data.SqlClient;
+using System.Threading;
+using System.Threading.Tasks;
+using Akka.Streams.Dsl;
+using Akka.Streams.Sql.Internal;
+using Akka.Streams.TestKit;
+using Akka.TestKit;
+using FluentAssertions;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Akka.Streams.Sql.Tests
+{
+    public sealed class Person
+    {
+        public int Id { get; set; }
+        public string Name { get; set; }
+    }
+
+    public class SqlSinkSpec : Akka.TestKit.Xunit2.TestKit
+    {
+        private readonly ActorMaterializer materializer;
+
+        public SqlSinkSpec(ITestOutputHelper output) : base(output: output)
+        {
+            materializer = Sys.Materializer();
+            DbHelper.InitDb();
+        }
+
+        [Fact]
+        public void SqlSink_should_execute_insert_commands()
+        {
+            var sql = @"INSERT INTO People(Id, Name) VALUES(@Id, @Name)";
+            using (var connection = new SqlConnection(DbHelper.ConnectionString))
+            {
+                connection.Open();
+                
+                var sink = CreateTestProbe();
+                var input = new[] {
+                    new Person { Id = 1, Name = "John" },
+                    new Person { Id = 2, Name = "Amy" },
+                    new Person { Id = 3, Name = "Billy" },
+                };
+                var completed = Source.From(input)
+                    .ToMaterialized(TestSink<Person>(sink, connection, sql), Keep.Right)
+                    .Run(materializer);
+
+                sink.ExpectMsg<GraphStageMessages.Push>();
+                sink.ExpectMsg<GraphStageMessages.Push>();
+                sink.ExpectMsg<GraphStageMessages.Push>();
+                sink.ExpectMsg<GraphStageMessages.UpstreamFinish>();
+
+                completed.Wait(TimeSpan.FromSeconds(5));
+                completed.IsFaulted.Should().BeFalse();
+                completed.IsCanceled.Should().BeFalse();
+                completed.Result.Should().Be(3L);
+            }
+        }
+
+        [Fact]
+        public void SqlSink_should_turn_conflate_into_bulk_insert_commands()
+        {
+            var sql = @"INSERT INTO People(Id, Name) VALUES(@Id, @Name)";
+            using (var connection = new SqlConnection(DbHelper.ConnectionString))
+            {
+                connection.Open();
+
+                var sink = CreateTestProbe();
+                var input = new[] {
+                    new Person { Id = 1, Name = "John" },
+                    new Person { Id = 2, Name = "Amy" },
+                    new Person { Id = 3, Name = "Billy" },
+                    new Person { Id = 4, Name = "Marceline" },
+                };
+                var completed = Source.From(input)
+                    .ConflateWithSeed(ImmutableList.Create, (acc, person) => acc.Add(person))
+                    .ToMaterialized(TestSink<ImmutableList<Person>>(sink, connection, sql), Keep.Right)
+                    .Run(materializer);
+
+                sink.ExpectMsg<GraphStageMessages.Push>(); // 1st push is immediate
+                sink.ExpectMsg<GraphStageMessages.Push>(); // 3 pushes are conflated into a single one, 
+                                                           //   since we're waiting for insert to complete
+                sink.ExpectMsg<GraphStageMessages.UpstreamFinish>();
+
+                completed.Wait(TimeSpan.FromSeconds(5));
+                completed.Result.Should().Be(4);
+            }
+        }
+
+        protected override void Dispose(bool disposing)
+        {
+            materializer.Dispose();
+            base.Dispose(disposing);
+            DbHelper.Cleanup();
+        }
+
+        private TestSinkStage<T, Task<long>> TestSink<T>(TestProbe probe, DbConnection connection, string sql) =>
+            TestSinkStage<T, Task<long>>.Create(new SqlSinkStage<T>(connection, sql), probe);
+    }
+}

--- a/Sql/src/Akka.Streams.Sql.Tests/packages.config
+++ b/Sql/src/Akka.Streams.Sql.Tests/packages.config
@@ -1,0 +1,19 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="Akka" version="1.1.3" targetFramework="net451" />
+  <package id="Akka.Streams" version="1.1.3.32-beta" targetFramework="net451" />
+  <package id="Akka.Streams.TestKit" version="1.1.3.32-beta" targetFramework="net451" />
+  <package id="Akka.TestKit" version="1.1.3" targetFramework="net451" />
+  <package id="Akka.TestKit.Xunit2" version="1.1.3" targetFramework="net451" />
+  <package id="Dapper" version="1.50.2" targetFramework="net451" />
+  <package id="FluentAssertions" version="4.19.2" targetFramework="net451" />
+  <package id="Newtonsoft.Json" version="9.0.1" targetFramework="net451" />
+  <package id="Reactive.Streams" version="1.0.0-RC1" targetFramework="net451" />
+  <package id="System.Collections.Immutable" version="1.1.36" targetFramework="net451" />
+  <package id="xunit" version="2.1.0" targetFramework="net451" />
+  <package id="xunit.abstractions" version="2.0.0" targetFramework="net451" />
+  <package id="xunit.assert" version="2.1.0" targetFramework="net451" />
+  <package id="xunit.core" version="2.1.0" targetFramework="net451" />
+  <package id="xunit.extensibility.core" version="2.1.0" targetFramework="net451" />
+  <package id="xunit.extensibility.execution" version="2.1.0" targetFramework="net451" />
+</packages>

--- a/Sql/src/Akka.Streams.Sql.sln
+++ b/Sql/src/Akka.Streams.Sql.sln
@@ -1,0 +1,34 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio 14
+VisualStudioVersion = 14.0.25420.1
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "src", "src", "{0596BBAF-C27D-43E9-AB66-1886630B8DA6}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Akka.Streams.Sql", "Akka.Streams.Sql\Akka.Streams.Sql\Akka.Streams.Sql.csproj", "{763EB487-15AF-4BAD-A272-5A9AEB95F9F4}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Akka.Streams.Sql.Tests", "Akka.Streams.Sql.Tests\Akka.Streams.Sql.Tests.csproj", "{81C7A17D-6A96-41A1-A8C5-3735CFA3C640}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{763EB487-15AF-4BAD-A272-5A9AEB95F9F4}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{763EB487-15AF-4BAD-A272-5A9AEB95F9F4}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{763EB487-15AF-4BAD-A272-5A9AEB95F9F4}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{763EB487-15AF-4BAD-A272-5A9AEB95F9F4}.Release|Any CPU.Build.0 = Release|Any CPU
+		{81C7A17D-6A96-41A1-A8C5-3735CFA3C640}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{81C7A17D-6A96-41A1-A8C5-3735CFA3C640}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{81C7A17D-6A96-41A1-A8C5-3735CFA3C640}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{81C7A17D-6A96-41A1-A8C5-3735CFA3C640}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(NestedProjects) = preSolution
+		{763EB487-15AF-4BAD-A272-5A9AEB95F9F4} = {0596BBAF-C27D-43E9-AB66-1886630B8DA6}
+		{81C7A17D-6A96-41A1-A8C5-3735CFA3C640} = {0596BBAF-C27D-43E9-AB66-1886630B8DA6}
+	EndGlobalSection
+EndGlobal

--- a/Sql/src/Akka.Streams.Sql/Akka.Streams.Sql/Akka.Streams.Sql.csproj
+++ b/Sql/src/Akka.Streams.Sql/Akka.Streams.Sql/Akka.Streams.Sql.csproj
@@ -1,0 +1,84 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectGuid>{763EB487-15AF-4BAD-A272-5A9AEB95F9F4}</ProjectGuid>
+    <OutputType>Library</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <RootNamespace>Akka.Streams.Sql</RootNamespace>
+    <AssemblyName>Akka.Streams.Sql</AssemblyName>
+    <TargetFrameworkVersion>v4.5.1</TargetFrameworkVersion>
+    <FileAlignment>512</FileAlignment>
+    <TargetFrameworkProfile />
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\Release\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="Akka, Version=1.1.3.31, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Akka.1.1.3\lib\net45\Akka.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="Akka.Streams, Version=1.1.3.32, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Akka.Streams.1.1.3.32-beta\lib\net45\Akka.Streams.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="Dapper, Version=1.50.2.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Dapper.1.50.2\lib\net451\Dapper.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="Newtonsoft.Json, Version=9.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Newtonsoft.Json.9.0.1\lib\net45\Newtonsoft.Json.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="Reactive.Streams, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Reactive.Streams.1.0.0-RC1\lib\portable-net45+netcore45\Reactive.Streams.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="System" />
+    <Reference Include="System.Collections.Immutable, Version=1.1.36.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\System.Collections.Immutable.1.1.36\lib\portable-net45+win8+wp8+wpa81\System.Collections.Immutable.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="System.Core" />
+    <Reference Include="System.Xml.Linq" />
+    <Reference Include="System.Data.DataSetExtensions" />
+    <Reference Include="Microsoft.CSharp" />
+    <Reference Include="System.Data" />
+    <Reference Include="System.Net.Http" />
+    <Reference Include="System.Xml" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="SqlSink.cs" />
+    <Compile Include="Internal\SqlSinkStage.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="packages.config" />
+  </ItemGroup>
+  <ItemGroup />
+  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
+       Other similar extension points exist, see Microsoft.Common.targets.
+  <Target Name="BeforeBuild">
+  </Target>
+  <Target Name="AfterBuild">
+  </Target>
+  -->
+</Project>

--- a/Sql/src/Akka.Streams.Sql/Akka.Streams.Sql/Internal/SqlSinkStage.cs
+++ b/Sql/src/Akka.Streams.Sql/Akka.Streams.Sql/Internal/SqlSinkStage.cs
@@ -1,0 +1,122 @@
+﻿using System;
+using System.Data.Common;
+using System.Threading.Tasks;
+using Akka.Streams.Stage;
+using Dapper;
+
+namespace Akka.Streams.Sql.Internal
+{
+    internal sealed class SqlSinkStage<T> : GraphStageWithMaterializedValue<SinkShape<T>, Task<long>>
+    {
+        private readonly DbConnection connection;
+        private readonly string sql;
+        private readonly Inlet<T> inlet = new Inlet<T>("dapper.in");
+        private readonly TaskCompletionSource<long> completion;
+
+        public SqlSinkStage(DbConnection connection, string sql)
+        {
+            this.connection = connection;
+            this.sql = sql;
+            completion = new TaskCompletionSource<long>();
+            Shape = new SinkShape<T>(inlet);
+        }
+
+        public override SinkShape<T> Shape { get; }
+
+        public override ILogicAndMaterializedValue<Task<long>> CreateLogicAndMaterializedValue(Attributes inheritedAttributes)
+        {
+            return new LogicAndMaterializedValue<Task<long>>(new Logic(this), completion.Task);
+        }
+
+        #region logic
+
+        private sealed class Logic : InGraphStageLogic
+        {
+            private readonly SqlSinkStage<T> stage;
+            private readonly Action<int> onSuccess;
+            private readonly Action<Exception> onFailure;
+            private long executedResult = 0;
+            
+            // those 2 flags are required in order to graceful stream completion
+            // for that to happen both shutdown must have been called
+            // and the last operation must completed (this way we prevent from
+            // a premature completion of materialized value)
+            private bool isShutdownInProgress = false;
+            private bool isOperationInProgress = false;
+
+            public Logic(SqlSinkStage<T> stage) : base(stage.Shape)
+            {
+                this.stage = stage;
+                this.onSuccess = GetAsyncCallback<int>(HandleSuccess);
+                this.onFailure = GetAsyncCallback<Exception>(HandleFailure);
+
+                SetHandler(stage.inlet, this);
+            }
+
+            public override void PreStart()
+            {
+                // this stage must keep running after upstream finished
+                // it's necessary to complete the last request first before calling for completion
+                // all stream completion events must be called manually this way
+                SetKeepGoing(true);
+                Pull(stage.inlet);
+            }
+
+            public override void OnPush()
+            {
+                var msg = Grab(stage.inlet);
+                isOperationInProgress = true;
+                stage.connection
+                    .ExecuteAsync(stage.sql, msg)
+                    .ContinueWith(HandleContinuation);
+            }
+
+            public override void OnUpstreamFailure(Exception cause)
+            {
+                isShutdownInProgress = true;
+                FailStage(cause);
+                stage.completion.SetException(cause);
+            }
+
+            public override void OnUpstreamFinish()
+            {
+                isShutdownInProgress = true;
+                TryShutdown();
+            }
+
+            private void HandleContinuation(Task<int> task)
+            {
+                if (task.IsFaulted || task.IsCanceled)
+                    onFailure(task.Exception);
+                else
+                    onSuccess(task.Result);
+            }
+
+            private void HandleFailure(Exception cause)
+            {
+                isOperationInProgress = false;
+                FailStage(cause);
+                stage.completion.SetException(cause);
+            }
+
+            private void HandleSuccess(int scalar)
+            {
+                executedResult += scalar;
+                isOperationInProgress = false;
+                TryShutdown();
+                TryPull(stage.inlet);
+            }
+            
+            private void TryShutdown()
+            {
+                if (isShutdownInProgress && !isOperationInProgress)
+                {
+                    CompleteStage();
+                    stage.completion.SetResult(executedResult);
+                }
+            }
+        }
+
+        #endregion
+    }
+}

--- a/Sql/src/Akka.Streams.Sql/Akka.Streams.Sql/Properties/AssemblyInfo.cs
+++ b/Sql/src/Akka.Streams.Sql/Akka.Streams.Sql/Properties/AssemblyInfo.cs
@@ -1,0 +1,37 @@
+﻿using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+// General Information about an assembly is controlled through the following 
+// set of attributes. Change these attribute values to modify the information
+// associated with an assembly.
+[assembly: AssemblyTitle("Akka.Streams.Sql")]
+[assembly: AssemblyDescription("")]
+[assembly: AssemblyConfiguration("")]
+[assembly: AssemblyCompany("")]
+[assembly: AssemblyProduct("Akka.Streams.Sql")]
+[assembly: AssemblyCopyright("Copyright ©  2017")]
+[assembly: AssemblyTrademark("")]
+[assembly: AssemblyCulture("")]
+
+// Setting ComVisible to false makes the types in this assembly not visible 
+// to COM components.  If you need to access a type in this assembly from 
+// COM, set the ComVisible attribute to true on that type.
+[assembly: ComVisible(false)]
+
+// The following GUID is for the ID of the typelib if this project is exposed to COM
+[assembly: Guid("763eb487-15af-4bad-a272-5a9aeb95f9f4")]
+
+// Version information for an assembly consists of the following four values:
+//
+//      Major Version
+//      Minor Version 
+//      Build Number
+//      Revision
+//
+// You can specify all the values or you can default the Build and Revision Numbers 
+// by using the '*' as shown below:
+// [assembly: AssemblyVersion("1.0.*")]
+[assembly: AssemblyVersion("1.0.0.0")]
+[assembly: AssemblyFileVersion("1.0.0.0")]
+[assembly: InternalsVisibleTo("Akka.Streams.Sql.Tests")]

--- a/Sql/src/Akka.Streams.Sql/Akka.Streams.Sql/SqlSink.cs
+++ b/Sql/src/Akka.Streams.Sql/Akka.Streams.Sql/SqlSink.cs
@@ -1,0 +1,56 @@
+﻿using System.Collections.Generic;
+using System.Data.Common;
+using System.Threading.Tasks;
+using Akka.Streams.Dsl;
+using Akka.Streams.Sql.Internal;
+
+namespace Akka.Streams.Sql
+{
+    /// <summary>
+    /// A static class that may be used to run SQL non-query statements. 
+    /// Objects comming from upstream are executed as SQL command parameters 
+    /// using Dapper micro ORM.
+    /// </summary>
+    public static class SqlSink
+    {
+        /// <summary>
+        /// <para>
+        /// Creates a sink which uses existing SQL connection to insert series 
+        /// of objects comming from upstream. Objects are inserted as command 
+        /// params using Dapper micro ORM. I.e. <see cref="IEnumerable{T}"/> 
+        /// objects will be translated into bulk inserts.
+        /// 
+        /// This implementation will only execute SQL statements one by one and 
+        /// will block upstream from sending overwhelming amoung of requests.
+        /// 
+        /// Materialized value will complete after both upstream and the last 
+        /// executed statement will finish and it will return total number of 
+        /// records affected by executed commands during graph lifetime.
+        /// </para>
+        /// <para>
+        /// Fails when upstream fails or connection executing SQL statement 
+        /// fails.
+        /// </para>
+        /// <para>
+        /// Finished when both upstream finishes and connection completed SQL 
+        /// statement execution.
+        /// </para>
+        /// </summary>
+        /// <typeparam name="T">
+        /// Plain old class object type translated into SQL command params.
+        /// </typeparam>
+        /// <param name="connection">
+        /// Opened connection to a database where <paramref name="sqlCommand"/> 
+        /// is going to be executed.
+        /// </param>
+        /// <param name="sqlCommand">
+        /// Non-query sql statement with params matching <typeparamref name="T"/> 
+        /// type fields.
+        /// </param>
+        /// <returns></returns>
+        public static Sink<T, Task<long>> Sink<T>(DbConnection connection, string sqlCommand)
+        {
+            return Dsl.Sink.FromGraph(new SqlSinkStage<T>(connection, sqlCommand));
+        }
+    }
+}

--- a/Sql/src/Akka.Streams.Sql/Akka.Streams.Sql/packages.config
+++ b/Sql/src/Akka.Streams.Sql/Akka.Streams.Sql/packages.config
@@ -1,0 +1,9 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="Akka" version="1.1.3" targetFramework="net451" />
+  <package id="Akka.Streams" version="1.1.3.32-beta" targetFramework="net451" />
+  <package id="Dapper" version="1.50.2" targetFramework="net451" />
+  <package id="Newtonsoft.Json" version="9.0.1" targetFramework="net451" />
+  <package id="Reactive.Streams" version="1.0.0-RC1" targetFramework="net451" />
+  <package id="System.Collections.Immutable" version="1.1.36" targetFramework="net451" />
+</packages>


### PR DESCRIPTION
**DO NOT MERGE: work in progress**

So far this PR introduces sink to SQL databases. It may be used for example to insert data directly from Akka.NET flow to a database, ie.:

```csharp
using (var system = ActorSystem.Create("system")
using (var materializer = system.Materializer())
using (var connection = new SqlConnection(connectionString))
{
    await connection.OpenAsync();

    var command = "INSERT INTO People(Id, Name) VALUES(@Id, @Name)";
    var input = new[] {
        new Person { Id = 1, Name = "John" },
        new Person { Id = 2, Name = "Amy" },
        new Person { Id = 3, Name = "Billy" },
    };
    var totalResult = await Source.From(input)
        .ToMaterialized(SqlSink.Sink(connection, command), Keep.Right)
        .Run(materializer);
}
```

Returned sink contains a materialized value in form of `Task<long>` which accumulated results of all executed non-query commands and returns it once upstream finishes and all pending operation has been completed.

Underneat this plugin makes use of [Dapper](https://github.com/StackExchange/Dapper) in order to convert incoming records into SQL command parameters.

This PR already contains passing specs, that shows how inserts work, and that `Conflate` may be used to run bulk insert operations (resolved by Dapper).

## TODO

What I want to introduce is to have another version of this sink, that will use connection pools in order to automatically manage `DBConnection` creation and to introduce optimal usage of resources - just like batching SQL journals I've [PRed](https://github.com/akkadotnet/Akka.Persistence.SqlServer/pull/56) and [posted about](http://bartoszsypytkowski.com/optimizing-event-journals/).