### PR TITLE
AmqpFlow

### DIFF
--- a/Amqp/src/Akka.Streams.Amqp.Tests/Akka.Streams.Amqp.Tests.csproj
+++ b/Amqp/src/Akka.Streams.Amqp.Tests/Akka.Streams.Amqp.Tests.csproj
@@ -3,10 +3,10 @@
     <TargetFrameworks>netstandard2.0;net46</TargetFrameworks>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Akka.Streams.TestKit" Version="1.3.2" />
-    <PackageReference Include="Akka.TestKit.Xunit2" Version="1.3.2" />
-    <PackageReference Include="FluentAssertions" Version="4.19.4" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.5.0" />
+    <PackageReference Include="Akka.Streams.TestKit" Version="1.3.5" />
+    <PackageReference Include="Akka.TestKit.Xunit2" Version="1.3.5" />
+    <PackageReference Include="FluentAssertions" Version="5.1.2" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.6.0" />
     <PackageReference Include="System.ValueTuple" Version="4.4.0" />
     <PackageReference Include="xunit" Version="2.3.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.3.1" />

--- a/Amqp/src/Akka.Streams.Amqp/Akka.Streams.Amqp.csproj
+++ b/Amqp/src/Akka.Streams.Amqp/Akka.Streams.Amqp.csproj
@@ -13,7 +13,7 @@
     <PackageLicenseUrl>https://github.com/AkkaNetContrib/Alpakka/blob/dev/LICENSE</PackageLicenseUrl>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Akka.Streams" Version="1.3.2" />
+    <PackageReference Include="Akka.Streams" Version="1.3.5" />
     <PackageReference Include="RabbitMQ.Client" Version="5.0.1" />
     <PackageReference Include="System.ValueTuple" Version="4.4.0" />
   </ItemGroup>

--- a/Amqp/src/Akka.Streams.Amqp/AmqpFlowStage.cs
+++ b/Amqp/src/Akka.Streams.Amqp/AmqpFlowStage.cs
@@ -1,0 +1,108 @@
+﻿using System;
+using System.Threading.Tasks;
+using Akka.Streams.Stage;
+using RabbitMQ.Client;
+
+namespace Akka.Streams.Amqp
+{
+    /// <summary>
+    /// This stage materializes to a <see cref="T:System.Threading.Tasks.Task" />
+    /// </summary>
+    /// <inheritdoc />
+    public class AmqpFlowStage<TPassThrough> : GraphStageWithMaterializedValue<FlowShape<(OutgoingMessage, TPassThrough), TPassThrough>, Task>
+    {
+        public static readonly Attributes DefaultAttributes =
+            Attributes.CreateName("AmqpFlow").And(ActorAttributes.CreateDispatcher("akka.stream.default-blocking-io-dispatcher"));
+
+        public AmqpSinkSettings Settings { get; }
+        public readonly Inlet<(OutgoingMessage, TPassThrough)> In = new Inlet<(OutgoingMessage, TPassThrough)>("AmqpFlow.in");
+        public readonly Outlet<TPassThrough> Out = new Outlet<TPassThrough>("AmqpFlow.out");
+
+        public AmqpFlowStage(AmqpSinkSettings settings)
+        {
+            Settings = settings;
+            Shape = new FlowShape<(OutgoingMessage, TPassThrough), TPassThrough>(In, Out);
+        }
+
+        public override FlowShape<(OutgoingMessage, TPassThrough), TPassThrough> Shape { get; }
+        protected override Attributes InitialAttributes => DefaultAttributes;
+
+        public override ILogicAndMaterializedValue<Task> CreateLogicAndMaterializedValue(Attributes inheritedAttributes)
+        {
+            var promise = new TaskCompletionSource<Done>();
+            var logic = new Logic(this, promise);
+            return new LogicAndMaterializedValue<Task>(logic, promise.Task);
+        }
+
+        public override string ToString() => "AmqpFlow";
+
+        private class Logic : AmqpConnectorLogic
+        {
+            private readonly AmqpFlowStage<TPassThrough> _stage;
+            private Action<ShutdownEventArgs> _shutdownCallback;
+            private readonly TaskCompletionSource<Done> _promise;
+
+            public Logic(AmqpFlowStage<TPassThrough> stage, TaskCompletionSource<Done> promise) : base(stage.Shape)
+            {
+                _promise = promise;
+                _stage = stage;
+
+                SetHandler(_stage.Out, onPull: () => Pull(_stage.In));
+
+                SetHandler(_stage.In,
+                    onPush: () =>
+                    {
+                        var (elem, passThrough) = Grab(_stage.In);
+                        Channel.BasicPublish(
+                            Exchange,
+                            elem.RoutingKey ?? RoutingKey,
+                            elem.Mandatory,
+                            elem.Properties,
+                            elem.Bytes.ToArray());
+
+                        Push(_stage.Out, passThrough);
+                        //Pull(_stage.In);
+                    },
+                    onUpstreamFinish: () => _promise.TrySetResult(Done.Instance),
+                    onUpstreamFailure: ex => _promise.TrySetException(ex));
+            }
+
+            public string Exchange => _stage.Settings.Exchange ?? "";
+
+            public string RoutingKey => _stage.Settings.RoutingKey ?? "";
+
+            public override IAmqpConnectorSettings Settings => _stage.Settings;
+
+            public override IConnectionFactory ConnectionFactoryFrom(IAmqpConnectionSettings settings) =>
+                AmqpConnector.ConnectionFactoryFrom(settings);
+
+            public override IConnection NewConnection(IConnectionFactory factory, IAmqpConnectionSettings settings) =>
+                AmqpConnector.NewConnection(factory, settings);
+
+            public override void WhenConnected()
+            {
+                _shutdownCallback = GetAsyncCallback<ShutdownEventArgs>(args =>
+                {
+                    var exception = ShutdownSignalException.FromArgs(args);
+                    _promise.SetException(exception);
+                    FailStage(exception);
+                });
+
+                Channel.ModelShutdown += OnChannelShutdown;
+                Pull(_stage.In);
+            }
+
+            private void OnChannelShutdown(object sender, ShutdownEventArgs shutdownEventArgs) => _shutdownCallback?.Invoke(shutdownEventArgs);
+
+            public override void PostStop()
+            {
+                _promise.TrySetException(new ApplicationException("stage stopped unexpectedly"));
+                if (Channel != null)
+                    Channel.ModelShutdown -= OnChannelShutdown;
+                base.PostStop();
+            }
+
+            public override void OnFailure(Exception ex) => _promise.TrySetException(ex);
+        }
+    }
+}

--- a/Amqp/src/Akka.Streams.Amqp/Dsl/AmqpFlow.cs
+++ b/Amqp/src/Akka.Streams.Amqp/Dsl/AmqpFlow.cs
@@ -1,0 +1,19 @@
+﻿using System.Threading.Tasks;
+using Akka.IO;
+using Akka.Streams.Dsl;
+
+namespace Akka.Streams.Amqp.Dsl
+{
+    public static class AmqpFlow
+    {
+        /// <summary>
+        /// Create a flow that publishes messages to RabbitMQ.
+        /// </summary>
+        /// <param name="settings"></param>
+        /// <returns>TBD</returns>
+        public static Flow<(OutgoingMessage, TPassThrough), TPassThrough, Task> Create<TPassThrough>(AmqpSinkSettings settings)
+        {
+            return Flow.FromGraph(new AmqpFlowStage<TPassThrough>(settings));
+        }
+    }
+}


### PR DESCRIPTION
The test fails with
```
Akka.Streams.Amqp.Tests.AmqpConnectorsTest.Publish_elements_with_flow_then_consume_them_with_source

System.AggregateException : One or more errors occurred.
---- System.ArgumentException : Cannot pull port twice
   at System.Threading.Tasks.Task`1.GetResultCore(Boolean waitCompletionNotification)
   at Akka.Streams.Amqp.Tests.AmqpConnectorsTest.Publish_elements_with_flow_then_consume_them_with_source() in D:\WLCR\github\Alpakka\Amqp\src\Akka.Streams.Amqp.Tests\AmqpConnectorsTest.cs:line 527
----- Inner Stack Trace -----
   at Akka.Streams.Stage.GraphStageLogic.Pull(Inlet inlet)
   at Akka.Streams.Amqp.AmqpFlowStage`1.Logic.<.ctor>b__3_0()
   at Akka.Streams.Implementation.Fusing.GraphInterpreter.ProcessEvent(Connection connection)
   at Akka.Streams.Implementation.Fusing.GraphInterpreter.Execute(Int32 eventLimit)
```
Please, help.