### PR TITLE
Migrate net461 -> netstandard2 for Storage Queue

### DIFF
--- a/Azure/src/Akka.Streams.Azure.StorageQueue.Tests/QueueSinkSpec.cs
+++ b/Azure/src/Akka.Streams.Azure.StorageQueue.Tests/QueueSinkSpec.cs
@@ -5,7 +5,7 @@ using Akka.Streams.Dsl;
 using Akka.Streams.Supervision;
 using Akka.Streams.TestKit;
 using FluentAssertions;
-using Microsoft.WindowsAzure.Storage.Queue;
+using Microsoft.Azure.Storage.Queue;
 using Xunit;
 
 namespace Akka.Streams.Azure.StorageQueue.Tests

--- a/Azure/src/Akka.Streams.Azure.StorageQueue.Tests/QueueSourceSpecs.cs
+++ b/Azure/src/Akka.Streams.Azure.StorageQueue.Tests/QueueSourceSpecs.cs
@@ -3,7 +3,7 @@ using Akka.Streams.Dsl;
 using Akka.Streams.Supervision;
 using Akka.Streams.TestKit;
 using FluentAssertions;
-using Microsoft.WindowsAzure.Storage.Queue;
+using Microsoft.Azure.Storage.Queue;
 using Xunit;
 
 namespace Akka.Streams.Azure.StorageQueue.Tests

--- a/Azure/src/Akka.Streams.Azure.StorageQueue.Tests/QueueSpecBase.cs
+++ b/Azure/src/Akka.Streams.Azure.StorageQueue.Tests/QueueSpecBase.cs
@@ -1,5 +1,6 @@
-﻿using Microsoft.WindowsAzure.Storage;
-using Microsoft.WindowsAzure.Storage.Queue;
+﻿using System;
+using Microsoft.Azure.Storage;
+using Microsoft.Azure.Storage.Queue;
 
 namespace Akka.Streams.Azure.StorageQueue.Tests
 {
@@ -10,7 +11,7 @@ namespace Akka.Streams.Azure.StorageQueue.Tests
             Materializer = Sys.Materializer();
 
             var client = CloudStorageAccount.DevelopmentStorageAccount.CreateCloudQueueClient();
-            Queue = client.GetQueueReference("testqueue");
+            Queue = client.GetQueueReference($"testqueue-{Guid.NewGuid()}");
             Queue.CreateIfNotExists();
         }
 

--- a/Azure/src/Akka.Streams.Azure.StorageQueue/Akka.Streams.Azure.StorageQueue.csproj
+++ b/Azure/src/Akka.Streams.Azure.StorageQueue/Akka.Streams.Azure.StorageQueue.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <AssemblyTitle>Akka.Streams.Azure.StorageQueue</AssemblyTitle>
     <Description>Azure Storage Queue adapter for Akka.NET Streams</Description>
-    <TargetFramework>net461</TargetFramework>
+    <TargetFramework>netstandard2.0</TargetFramework>
     <Copyright>Copyright © 2019 Akka.NET Contrib</Copyright>
     <Authors>Akka.NET Contrib</Authors>
     <VersionPrefix>0.1.2</VersionPrefix>
@@ -17,7 +17,7 @@
 
   <ItemGroup>
     <PackageReference Include="Akka.Streams" Version="1.3.11" />
-    <PackageReference Include="WindowsAzure.Storage" Version="9.3.3" />
+    <PackageReference Include="Microsoft.Azure.Storage.Queue" Version="11.0.0" />
   </ItemGroup>
 
 </Project>

--- a/Azure/src/Akka.Streams.Azure.StorageQueue/QueueSink.cs
+++ b/Azure/src/Akka.Streams.Azure.StorageQueue/QueueSink.cs
@@ -4,7 +4,7 @@ using Akka.Streams.Azure.Utils;
 using Akka.Streams.Dsl;
 using Akka.Streams.Stage;
 using Akka.Streams.Supervision;
-using Microsoft.WindowsAzure.Storage.Queue;
+using Microsoft.Azure.Storage.Queue;
 
 namespace Akka.Streams.Azure.StorageQueue
 {

--- a/Azure/src/Akka.Streams.Azure.StorageQueue/QueueSource.cs
+++ b/Azure/src/Akka.Streams.Azure.StorageQueue/QueueSource.cs
@@ -6,7 +6,7 @@ using Akka.Streams.Azure.Utils;
 using Akka.Streams.Dsl;
 using Akka.Streams.Stage;
 using Akka.Streams.Supervision;
-using Microsoft.WindowsAzure.Storage.Queue;
+using Microsoft.Azure.Storage.Queue;
 
 namespace Akka.Streams.Azure.StorageQueue
 {

--- a/Azure/src/Akka.Streams.Azure.StorageQueue/RequestOptions.cs
+++ b/Azure/src/Akka.Streams.Azure.StorageQueue/RequestOptions.cs
@@ -1,6 +1,6 @@
+using Microsoft.Azure.Storage;
+using Microsoft.Azure.Storage.Queue;
 using System;
-using Microsoft.WindowsAzure.Storage;
-using Microsoft.WindowsAzure.Storage.Queue;
 
 namespace Akka.Streams.Azure.StorageQueue
 {

--- a/Azure/src/Akka.Streams.Azure.StorageQueue/SourceExtension.cs
+++ b/Azure/src/Akka.Streams.Azure.StorageQueue/SourceExtension.cs
@@ -1,6 +1,6 @@
 ﻿using System.Threading.Tasks;
 using Akka.Streams.Dsl;
-using Microsoft.WindowsAzure.Storage.Queue;
+using Microsoft.Azure.Storage.Queue;
 
 namespace Akka.Streams.Azure.StorageQueue
 {


### PR DESCRIPTION
The simplest implementation of #58 
- [x] Change target framework
- [x] Update Azure Storage Queue library ([WindowsAzure lib](https://www.nuget.org/packages/WindowsAzure.Storage/) is replaced by [Microsoft Azure lib](https://www.nuget.org/packages/Microsoft.Azure.Storage.Queue/]))
- [x] Allow parallel tests by introducing random queue name
- [x] Keep existing tests green  
![2019-09-01_19-13-56](https://user-images.githubusercontent.com/3256574/64079823-be62b980-ccec-11e9-8db6-0c14aac79247.gif)
