### PR TITLE
Cleanup Akka.Streams.SignalR.AspNetCore code

### DIFF
--- a/src/SignalR.AspNetCore/Akka.Streams.SignalR.AspNetCore/ConnectionSettings.cs
+++ b/src/SignalR.AspNetCore/Akka.Streams.SignalR.AspNetCore/ConnectionSettings.cs
@@ -5,16 +5,16 @@ using Akka.Configuration;
 
 namespace Akka.Streams.SignalR.AspNetCore
 {
-    public class ConnectionSinkSettings
+    public sealed class ConnectionSinkSettings
     {
         public static readonly ConnectionSinkSettings Default = new ConnectionSinkSettings();
 
-        public ConnectionSinkSettings()
+        private ConnectionSinkSettings()
         {
         }
     }
 
-    public class ConnectionSourceSettings
+    public sealed class ConnectionSourceSettings
     {
         public static readonly ConnectionSourceSettings Default = 
             new ConnectionSourceSettings(
@@ -30,7 +30,7 @@ namespace Akka.Streams.SignalR.AspNetCore
         {
             if (config == null) throw new ArgumentException("Config for SignalR stream connection source must be provided. Default HOCON config path is: 'akka.streams.signalr.source'.");
 
-            Streams.OverflowStrategy overflowStrategy;
+            OverflowStrategy overflowStrategy;
             var overflowConfig = config.GetString("overflow-strategy", "drop-head");
             switch (overflowConfig)
             {
@@ -79,7 +79,7 @@ namespace Akka.Streams.SignalR.AspNetCore
             int? bufferSize = null,
             OverflowStrategy? overflowStrategy = null) =>
             new ConnectionSourceSettings(
-                bufferCapacity: bufferSize ?? this.BufferCapacity,
-                overflowStrategy: overflowStrategy ?? this.OverflowStrategy);
+                bufferCapacity: bufferSize ?? BufferCapacity,
+                overflowStrategy: overflowStrategy ?? OverflowStrategy);
     }
 }

--- a/src/SignalR.AspNetCore/Akka.Streams.SignalR.AspNetCore/Internals/DefaultStreamDispatcher.cs
+++ b/src/SignalR.AspNetCore/Akka.Streams.SignalR.AspNetCore/Internals/DefaultStreamDispatcher.cs
@@ -10,7 +10,7 @@ namespace Akka.Streams.SignalR.AspNetCore.Internals
     public sealed class DefaultStreamDispatcher : IStreamDispatcher
     {
         private readonly IServiceProvider _provider;
-        private ConcurrentDictionary<Type, StreamConnector> connectors
+        private readonly ConcurrentDictionary<Type, StreamConnector> _connectors
             = new ConcurrentDictionary<Type, StreamConnector>();
 
         private readonly ConnectionSourceSettings _sourceSettings;
@@ -35,7 +35,7 @@ namespace Akka.Streams.SignalR.AspNetCore.Internals
         private StreamConnector GetStream<TStream>(Type hubType)
             where TStream : StreamConnector
         {
-            return connectors.GetOrAdd(typeof(TStream), _ => {
+            return _connectors.GetOrAdd(typeof(TStream), _ => {
 
                 var hubContextType = typeof(IHubContext<>).MakeGenericType(hubType);
                 var hubContext = _provider.GetService(hubContextType);
@@ -44,7 +44,7 @@ namespace Akka.Streams.SignalR.AspNetCore.Internals
                 var stream = ActivatorUtilities.CreateInstance<TStream>(_provider,
                     hubClients,
                     _sourceSettings ?? new ConnectionSourceSettings(100, OverflowStrategy.DropTail),
-                    _sinkSettings ?? new ConnectionSinkSettings());
+                    _sinkSettings ?? ConnectionSinkSettings.Default);
 
                 return stream;
             });

--- a/src/SignalR.AspNetCore/Akka.Streams.SignalR.AspNetCore/Messages.cs
+++ b/src/SignalR.AspNetCore/Akka.Streams.SignalR.AspNetCore/Messages.cs
@@ -1,4 +1,5 @@
 ﻿using System.Collections.Generic;
+﻿using System;
 
 namespace Akka.Streams.SignalR.AspNetCore
 {
@@ -10,10 +11,10 @@ namespace Akka.Streams.SignalR.AspNetCore
         public static ISignalRResult Send(string connectionId, object data)
             => new Send(connectionId, data);
 
-        public static ISignalRResult SendToGroup(string group, object data, IList<string> excluded = null)
+        public static ISignalRResult SendToGroup(string group, object data, IReadOnlyList<string> excluded = null)
             => new Send(group, data, excluded);
 
-        public static ISignalRResult Broadcast(object data, string[] excluded = null)
+        public static ISignalRResult Broadcast(object data, IReadOnlyList<string> excluded = null)
             => new Broadcast(data, excluded);
     }
 
@@ -30,18 +31,18 @@ namespace Akka.Streams.SignalR.AspNetCore
 
     public sealed class Send : ISignalRResult
     {
-        private static string[] empty = new string[0];
+        private static readonly string[] Empty = Array.Empty<string>();
 
         public string ConnectionId { get; }
         public string Group { get; }
-        public IList<string> ExcludedConnectionIds { get; }
+        public IReadOnlyList<string> ExcludedConnectionIds { get; }
         public object Data { get; }
 
-        public Send(string group, object data, IList<string> excludedConnectionIds)
+        public Send(string group, object data, IReadOnlyList<string> excludedConnectionIds)
         {
             Group = group;
             Data = data;
-            ExcludedConnectionIds = excludedConnectionIds ?? empty;
+            ExcludedConnectionIds = excludedConnectionIds ?? Empty;
         }
 
         public Send(string connectionId, object data)
@@ -53,15 +54,15 @@ namespace Akka.Streams.SignalR.AspNetCore
 
     public sealed class Broadcast : ISignalRResult
     {
-        private static string[] empty = new string[0];
+        private static readonly string[] Empty = Array.Empty<string>();
 
         public object Data { get; }
-        public string[] ExcludedConnectionIds { get; }
+        public IReadOnlyList<string> ExcludedConnectionIds { get; }
 
-        public Broadcast(object data, string[] excludedConnectionIds = null)
+        public Broadcast(object data, IReadOnlyList<string> excludedConnectionIds = null)
         {
             Data = data;
-            ExcludedConnectionIds = excludedConnectionIds ?? empty;
+            ExcludedConnectionIds = excludedConnectionIds ?? Empty;
         }
     }
 }

--- a/src/SignalR.AspNetCore/Akka.Streams.SignalR.AspNetCore/ServicesExtensions.cs
+++ b/src/SignalR.AspNetCore/Akka.Streams.SignalR.AspNetCore/ServicesExtensions.cs
@@ -12,8 +12,10 @@ namespace Microsoft.Extensions.DependencyInjection
         /// Add SignalR Akka Stream connector
         /// </summary>
         /// <param name="services"></param>
-        public static void AddSignalRAkkaStream(this IServiceCollection services)
-            => services.Add(new ServiceDescriptor(typeof(IStreamDispatcher), 
-                typeof(DefaultStreamDispatcher), ServiceLifetime.Singleton));
+        public static IServiceCollection AddSignalRAkkaStream(this IServiceCollection services)
+        {
+            services.AddSingleton<IStreamDispatcher, DefaultStreamDispatcher>();
+            return services;
+        }
     }
 }

--- a/src/SignalR.AspNetCore/Akka.Streams.SignalR.AspNetCore/StreamConnector.cs
+++ b/src/SignalR.AspNetCore/Akka.Streams.SignalR.AspNetCore/StreamConnector.cs
@@ -21,10 +21,10 @@ namespace Akka.Streams.SignalR.AspNetCore
         /// <param name="clients"></param>
         /// <param name="sourceSettings">Optional settings used to configure the <see cref="Source"/>.</param>
         /// <param name="sinkSettings">Optional settings used to configure the <see cref="Sink"/>.</param>
-        public StreamConnector(IHubClients clients, ConnectionSourceSettings sourceSettings = null, ConnectionSinkSettings sinkSettings = null)
+        protected StreamConnector(IHubClients clients, ConnectionSourceSettings sourceSettings = null, ConnectionSinkSettings sinkSettings = null)
         {
-            this.Sink = Dsl.Sink.FromGraph(new SignalRSinkStage(clients, sinkSettings ?? ConnectionSinkSettings.Default));
-            this.Source = Dsl.Source.FromGraph(new SignalRSourceStage(this, sourceSettings ?? ConnectionSourceSettings.Default));
+            Sink = Dsl.Sink.FromGraph(new SignalRSinkStage(clients, sinkSettings ?? ConnectionSinkSettings.Default));
+            Source = Dsl.Source.FromGraph(new SignalRSourceStage(this, sourceSettings ?? ConnectionSourceSettings.Default));
         }
 
         /// <summary>

--- a/src/SignalR.AspNetCore/Akka.Streams.SignalR.AspNetCore/StreamHub.cs
+++ b/src/SignalR.AspNetCore/Akka.Streams.SignalR.AspNetCore/StreamHub.cs
@@ -15,7 +15,7 @@ namespace Akka.Streams.SignalR.AspNetCore
     {
         private readonly IStreamDispatcher _dispatcher;
 
-        public StreamHub(IStreamDispatcher dispatcher)
+        protected StreamHub(IStreamDispatcher dispatcher)
         {
             _dispatcher = dispatcher;
         }


### PR DESCRIPTION
Cleanup the code:
- Use underline prefix for private variables.
- Make variables read-only when necessary.
- Change Array properties to IReadOnlyList.
- Seal settings class.
- Change abstract class constructor access to protected
- Use Asp.NET conventions for code readability.