### PR TITLE
Fix racy System.Threading.Channels test

### DIFF
--- a/src/Channels/Akka.Streams.Channels.Tests/ChannelSourceSpec.cs
+++ b/src/Channels/Akka.Streams.Channels.Tests/ChannelSourceSpec.cs
@@ -66,7 +66,7 @@ namespace Akka.Streams.Channels.Tests
             probe.ExpectError().InnerException.Should().Be(failure);
         }
 
-        [Fact(Skip = "Test is very racy")]
+        [Fact]
         public async Task ChannelSource_must_read_incoming_events()
         {
             var tcs = new CancellationTokenSource(TimeSpan.FromSeconds(5));


### PR DESCRIPTION
Closes #83 

Probable cause was this code:
`var task = continuation.AsTask()`
Somehow, trying to pre-fetch the `Task` inside `ValueTask` can cause the `Task` inside the `ValueTask` to be executed twice, causing Channels to throw, because it will try to use an id token twice.