### PR TITLE
Move the docker images from private to organization dockerhub account

### DIFF
--- a/docs/community/Testing.md
+++ b/docs/community/Testing.md
@@ -32,7 +32,7 @@ The test suite expects a working AMQP broker with these default settings:
 
 - Edit the `environment.json` file inside the `Akka.Streams.Amqp.Tests` project. Set `ALPAKKA_AMQP_TEST_USEDOCKER` to true.
 - A pre-built docker container image can be obtained by running:
-  `docker pull arkatufus/rabbitmq:latest`
+  `docker pull akkadotnet/rabbitmq:latest`
 - The docker image will be automatically pulled the first time you run the AMQP test suite, if you do not have a local copy.
 
 ## Using the pre-built Docker container as an application
@@ -40,8 +40,8 @@ The test suite expects a working AMQP broker with these default settings:
 You can run the pre-built docker container as a background application so that it does not have to be loaded/unloaded every time tests are run:
 - Edit the `environment.json` file inside the `Akka.Streams.Amqp.Tests` project. Set `ALPAKKA_AMQP_TEST_USEDOCKER` to false.
 - Pull and run the image by running:
-  `docker pull arkatufus/rabbitmq:latest`
-  `docker run -d -p 4369:4369 -p 5672:5672 -p 5671:5671 -p 15672:15672 arkatufus/rabbitmq:latest`
+  `docker pull akkadotnet/rabbitmq:latest`
+  `docker run -d -p 4369:4369 -p 5672:5672 -p 5671:5671 -p 15672:15672 akkadotnet/rabbitmq:latest`
 - Wait until the application started and you can start testing.
 
 # Azure
@@ -59,13 +59,13 @@ You can run the pre-built docker container as a background application so that i
 ## Using a pre-built Docker container
 - The test suite can also be run against docker containers. 
 - To run the test suite against a Docker container, Edit the `environment.json` file inside the `Akka.Streams.Azure.StorageQueue.Tests` project. Set `ALPAKKA_AZURE_TEST_USEDOCKER` to true.
-- The containers used are `arkatufus/azure-storage-emulator:latest` for windows and `mcr.microsoft.com/azure-storage/azurite` for linux.
+- The containers used are `akkadotnet/azure-storage-emulator:latest` for windows and `mcr.microsoft.com/azure-storage/azurite` for linux.
 
 ## Using the pre-built Docker container as an application
 
 You can run the pre-built docker container as a background application so that it does not have to be loaded/unloaded every time tests are run:
 - Edit the `environment.json` file inside the `Akka.Streams.Azure.StorageQueue.Tests` project. Set `ALPAKKA_AZURE_TEST_USEDOCKER` to false.
 - Pull and run the image by running:
-  `docker pull arkatufus/azure-storage-emulator:latest`
-  `docker run -d -p 10000:10000 -p 10001:10001 -p 10002:10002 arkatufus/azure-storage-emulator:latest`
+  `docker pull akkadotnet/azure-storage-emulator:latest`
+  `docker run -d -p 10000:10000 -p 10001:10001 -p 10002:10002 akkadotnet/azure-storage-emulator:latest`
 - Wait until the application started and you can start testing.

--- a/src/Amqp/Akka.Streams.Amqp.Tests/AmqpFixture.cs
+++ b/src/Amqp/Akka.Streams.Amqp.Tests/AmqpFixture.cs
@@ -63,9 +63,9 @@ namespace Akka.Streams.Amqp.Tests
                 switch (OperatingSystem)
                 {
                     case OperatingSystem.Windows:
-                        return "arkatufus/rabbitmq";
+                        return "akkadotnet/rabbitmq";
                     case OperatingSystem.Linux:
-                        return "arkatufus/rabbitmq-linux";
+                        return "akkadotnet/rabbitmq-linux";
                     default:
                         throw new NotSupportedException($"Unsupported OS [{RuntimeInformation.OSDescription}]");
                 }

--- a/src/Azure/Akka.Streams.Azure.StorageQueue.Tests/AzureFixture.cs
+++ b/src/Azure/Akka.Streams.Azure.StorageQueue.Tests/AzureFixture.cs
@@ -59,7 +59,7 @@ namespace Akka.Streams.Azure.StorageQueue.Tests
                     case OperatingSystem.Linux:
                         return "mcr.microsoft.com/azure-storage/azurite";
                     case OperatingSystem.Windows:
-                        return "arkatufus/azure-storage-emulator";
+                        return "akkadotnet/azure-storage-emulator";
                     default:
                         throw new NotSupportedException($"Unsupported OS [{RuntimeInformation.OSDescription}]");
                 }

--- a/support/dockerfiles/AMQP/Linux/build.ps1
+++ b/support/dockerfiles/AMQP/Linux/build.ps1
@@ -1,2 +1,2 @@
-docker build -t arkatufus/rabbitmq-linux:3.8.6-alpine .
-docker tag arkatufus/rabbitmq-linux:3.8.6-alpine arkatufus/rabbitmq-linux:latest
+docker build -t akkadotnet/rabbitmq-linux:3.8.6-alpine .
+docker tag akkadotnet/rabbitmq-linux:3.8.6-alpine akkadotnet/rabbitmq-linux:latest

--- a/support/dockerfiles/AMQP/Linux/push.ps1
+++ b/support/dockerfiles/AMQP/Linux/push.ps1
@@ -1,3 +1,3 @@
 docker login
-docker push arkatufus/rabbitmq-linux:3.8.6-alpine
-docker push arkatufus/rabbitmq-linux:latest
+docker push akkadotnet/rabbitmq-linux:3.8.6-alpine
+docker push akkadotnet/rabbitmq-linux:latest

--- a/support/dockerfiles/AMQP/Linux/run.ps1
+++ b/support/dockerfiles/AMQP/Linux/run.ps1
@@ -1,4 +1,4 @@
 docker stop rabbitmq
 docker rm rabbitmq
 
-docker run -d --name rabbitmq arkatufus/rabbitmq-linux
+docker run -d --name rabbitmq akkadotnet/rabbitmq-linux

--- a/support/dockerfiles/AMQP/Windows/build.ps1
+++ b/support/dockerfiles/AMQP/Windows/build.ps1
@@ -1,2 +1,2 @@
-docker build -t arkatufus/rabbitmq:3.8.6-ltsc2019 .
-docker tag arkatufus/rabbitmq:3.8.6-ltsc2019 arkatufus/rabbitmq:latest
+docker build -t akkadotnet/rabbitmq:3.8.6-ltsc2019 .
+docker tag akkadotnet/rabbitmq:3.8.6-ltsc2019 akkadotnet/rabbitmq:latest

--- a/support/dockerfiles/AMQP/Windows/push.ps1
+++ b/support/dockerfiles/AMQP/Windows/push.ps1
@@ -1,3 +1,3 @@
 docker login
-docker push arkatufus/rabbitmq:3.8.6-ltsc2019
-docker push arkatufus/rabbitmq:latest
+docker push akkadotnet/rabbitmq:3.8.6-ltsc2019
+docker push akkadotnet/rabbitmq:latest

--- a/support/dockerfiles/AMQP/Windows/run.ps1
+++ b/support/dockerfiles/AMQP/Windows/run.ps1
@@ -1,4 +1,4 @@
 docker stop rabbitmq
 docker rm rabbitmq
 
-docker run -d --name rabbitmq arkatufus/rabbitmq
+docker run -d --name rabbitmq akkadotnet/rabbitmq

--- a/support/dockerfiles/Azure/Windows/build.ps1
+++ b/support/dockerfiles/Azure/Windows/build.ps1
@@ -1,2 +1,2 @@
-docker build -t arkatufus/azure-storage-emulator:ltsc2019 .
-docker tag arkatufus/azure-storage-emulator:ltsc2019 arkatufus/azure-storage-emulator:latest
+docker build -t akkadotnet/azure-storage-emulator:ltsc2019 .
+docker tag akkadotnet/azure-storage-emulator:ltsc2019 akkadotnet/azure-storage-emulator:latest

--- a/support/dockerfiles/Azure/Windows/push.ps1
+++ b/support/dockerfiles/Azure/Windows/push.ps1
@@ -1,3 +1,3 @@
 docker login
-docker push arkatufus/azure-storage-emulator:ltsc2019
-docker push arkatufus/azure-storage-emulator:latest
+docker push akkadotnet/azure-storage-emulator:ltsc2019
+docker push akkadotnet/azure-storage-emulator:latest

--- a/support/dockerfiles/Azure/Windows/run.ps1
+++ b/support/dockerfiles/Azure/Windows/run.ps1
@@ -1,4 +1,4 @@
 docker stop azure-storage-emulator
 docker rm azure-storage-emulator
 
-docker run -d --name azure-storage-emulator arkatufus/azure-storage-emulator
+docker run -d --name azure-storage-emulator akkadotnet/azure-storage-emulator


### PR DESCRIPTION
Closes #96 
Rename all docker references from arkatufus to akkadotnet.
This PR should work when all the images have been moved to the new home.