### PR TITLE
Add AMQP retry mechanism and example projects

### DIFF
--- a/src/Alpakka.sln
+++ b/src/Alpakka.sln
@@ -110,7 +110,13 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "docs", "docs", "{DF4BD2BE-9
 		..\docs\web.config = ..\docs\web.config
 	EndProjectSection
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Akka.Streams.Amqp.RabbitMq.Tests", "Amqp\Akka.Streams.Amqp.RabbitMq.Tests\Akka.Streams.Amqp.RabbitMq.Tests.csproj", "{9CD223E4-CB08-4043-8687-16FE139310B4}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Akka.Streams.Amqp.RabbitMq.Tests", "Amqp\Akka.Streams.Amqp.RabbitMq.Tests\Akka.Streams.Amqp.RabbitMq.Tests.csproj", "{9CD223E4-CB08-4043-8687-16FE139310B4}"
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Examples", "Examples", "{D2FE5AD5-7AF4-4749-82C6-5E1CAD4D0AAF}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Amqp.V1.Source", "Amqp\Examples\Amqp.V1.Source\Amqp.V1.Source.csproj", "{33CE5A75-2792-48F1-8F19-12473A531926}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Amqp.V1.Sink", "Amqp\Examples\Amqp.V1.Sink\Amqp.V1.Sink.csproj", "{80039FDA-5979-4AA2-B380-08AEE3C6EF26}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -226,6 +232,14 @@ Global
 		{9CD223E4-CB08-4043-8687-16FE139310B4}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{9CD223E4-CB08-4043-8687-16FE139310B4}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{9CD223E4-CB08-4043-8687-16FE139310B4}.Release|Any CPU.Build.0 = Release|Any CPU
+		{33CE5A75-2792-48F1-8F19-12473A531926}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{33CE5A75-2792-48F1-8F19-12473A531926}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{33CE5A75-2792-48F1-8F19-12473A531926}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{33CE5A75-2792-48F1-8F19-12473A531926}.Release|Any CPU.Build.0 = Release|Any CPU
+		{80039FDA-5979-4AA2-B380-08AEE3C6EF26}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{80039FDA-5979-4AA2-B380-08AEE3C6EF26}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{80039FDA-5979-4AA2-B380-08AEE3C6EF26}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{80039FDA-5979-4AA2-B380-08AEE3C6EF26}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -266,6 +280,9 @@ Global
 		{32584532-EF44-45E2-9E43-CFE13609785D} = {9A8B3B60-F75D-4906-B368-739CA08C25D4}
 		{DF4BD2BE-9280-481E-A155-271F68A291E0} = {EEA93301-F97B-49F0-BB08-33F7CC5A24BB}
 		{9CD223E4-CB08-4043-8687-16FE139310B4} = {9A8B3B60-F75D-4906-B368-739CA08C25D4}
+		{D2FE5AD5-7AF4-4749-82C6-5E1CAD4D0AAF} = {9A8B3B60-F75D-4906-B368-739CA08C25D4}
+		{33CE5A75-2792-48F1-8F19-12473A531926} = {D2FE5AD5-7AF4-4749-82C6-5E1CAD4D0AAF}
+		{80039FDA-5979-4AA2-B380-08AEE3C6EF26} = {D2FE5AD5-7AF4-4749-82C6-5E1CAD4D0AAF}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {BE1A9436-C6F6-4C73-9EB4-32DEC9C841A5}

--- a/src/Amqp/Akka.Streams.Amqp.V1.Tests/Properties/launchSettings.json
+++ b/src/Amqp/Akka.Streams.Amqp.V1.Tests/Properties/launchSettings.json
@@ -1,0 +1,7 @@
+{
+  "profiles": {
+    "Akka.Streams.Amqp.V1.Tests": {
+      "commandName": "Project"
+    }
+  }
+}

--- a/src/Amqp/Akka.Streams.Amqp.V1/AddressSinkSettings.cs
+++ b/src/Amqp/Akka.Streams.Amqp.V1/AddressSinkSettings.cs
@@ -1,0 +1,57 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using Akka.Serialization;
+using Amqp;
+using Amqp.Framing;
+using Amqp.Types;
+
+namespace Akka.Streams.Amqp.V1
+{
+    public class AddressSinkSettings<T> : IAmqpSinkSettings<T>
+    {
+        private readonly string _linkName;
+        private readonly string _queueName;
+        private readonly Serializer _serializer;
+        private readonly Address _address;
+
+        private Connection _connection;
+        private Session _session;
+
+        public AddressSinkSettings(
+            Address address,
+            string linkName,
+            string queueName,
+            Serializer serializer)
+        {
+            _address = address;
+            _linkName = linkName;
+            _queueName = queueName;
+            _serializer = serializer;
+        }
+
+        public byte[] GetBytes(T obj)
+        {
+            return _serializer.ToBinary(obj);
+        }
+
+        public SenderLink GetSenderLink()
+        {
+            if (_connection == null || _connection.IsClosed)
+                _connection = new Connection(_address);
+
+            if (_session == null || _session.IsClosed)
+                _session = new Session(_connection);
+
+            return new SenderLink(
+                _session, 
+                _linkName,
+                new Target
+                {
+                    Address = _queueName, 
+                    Capabilities = new[] { new Symbol("queue") }
+                }, 
+                null);
+        }
+    }
+}

--- a/src/Amqp/Akka.Streams.Amqp.V1/AddressSinkSettings.cs
+++ b/src/Amqp/Akka.Streams.Amqp.V1/AddressSinkSettings.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Text;
+using System.Threading.Tasks;
 using Akka.Serialization;
 using Amqp;
 using Amqp.Framing;
@@ -14,6 +15,7 @@ namespace Akka.Streams.Amqp.V1
         private readonly string _queueName;
         private readonly Serializer _serializer;
         private readonly Address _address;
+        private readonly object _lock = new object();
 
         private Connection _connection;
         private Session _session;
@@ -35,6 +37,24 @@ namespace Akka.Streams.Amqp.V1
         public byte[] GetBytes(T obj)
         {
             return _serializer.ToBinary(obj);
+        }
+
+        public void CloseConnection()
+        {
+            _session?.Close();
+            _connection?.Close();
+
+            _session = null;
+            _connection = null;
+        }
+
+        public async Task CloseConnectionAsync()
+        {
+            if(_session != null)
+                await _session.CloseAsync();
+
+            if(_connection != null)
+                await _connection.CloseAsync();
         }
 
         public SenderLink GetSenderLink()

--- a/src/Amqp/Akka.Streams.Amqp.V1/AddressSinkSettings.cs
+++ b/src/Amqp/Akka.Streams.Amqp.V1/AddressSinkSettings.cs
@@ -18,6 +18,8 @@ namespace Akka.Streams.Amqp.V1
         private Connection _connection;
         private Session _session;
 
+        public bool ManageConnection => true;
+
         public AddressSinkSettings(
             Address address,
             string linkName,

--- a/src/Amqp/Akka.Streams.Amqp.V1/AddressSourceSettings.cs
+++ b/src/Amqp/Akka.Streams.Amqp.V1/AddressSourceSettings.cs
@@ -42,6 +42,21 @@ namespace Akka.Streams.Amqp.V1
             return _serializer.FromBinary<T>(bString);
         }
 
+        public void CloseConnection()
+        {
+            _session?.Close();
+            _connection?.Close();
+        }
+
+        public async Task CloseConnectionAsync()
+        {
+            if (_session != null)
+                await _session.CloseAsync();
+
+            if (_connection != null)
+                await _connection.CloseAsync();
+        }
+
         public ReceiverLink GetReceiverLink() 
         {
             if(_connection == null || _connection.IsClosed)

--- a/src/Amqp/Akka.Streams.Amqp.V1/AddressSourceSettings.cs
+++ b/src/Amqp/Akka.Streams.Amqp.V1/AddressSourceSettings.cs
@@ -1,0 +1,62 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using System.Threading.Tasks;
+using Akka.Serialization;
+using Amqp;
+using Amqp.Framing;
+using Amqp.Types;
+
+namespace Akka.Streams.Amqp.V1
+{
+    public class AddressSourceSettings<T> : IAmqpSourceSettings<T>
+    {
+        private readonly string _linkName;
+        private readonly string _queueName;
+        private readonly Serializer _serializer;
+
+        public int Credit { get; }
+        private readonly Address _address;
+        private Connection _connection;
+        private Session _session;
+
+        public AddressSourceSettings(
+            Address address,
+            string linkName,
+            string queueName,
+            int credit,
+            Serializer serializer)
+        {
+            _address = address;
+            _linkName = linkName;
+            _queueName = queueName;
+            Credit = credit;
+            _serializer = serializer;
+        }
+
+        public T Convert(Message message)
+        {
+            var bString = message.GetBody<byte[]>();
+            return _serializer.FromBinary<T>(bString);
+        }
+
+        public ReceiverLink GetReceiverLink() 
+        {
+            if(_connection == null || _connection.IsClosed)
+                _connection = new Connection(_address);
+
+            if (_session == null || _session.IsClosed)
+                _session = new Session(_connection);
+
+            return new ReceiverLink(
+                _session, 
+                _linkName,
+                new Source
+                {
+                    Address = _queueName, 
+                    Capabilities = new[] { new Symbol("queue") }
+                }, 
+                null);
+        }
+    }
+}

--- a/src/Amqp/Akka.Streams.Amqp.V1/AddressSourceSettings.cs
+++ b/src/Amqp/Akka.Streams.Amqp.V1/AddressSourceSettings.cs
@@ -20,6 +20,8 @@ namespace Akka.Streams.Amqp.V1
         private Connection _connection;
         private Session _session;
 
+        public bool ManageConnection => true;
+
         public AddressSourceSettings(
             Address address,
             string linkName,

--- a/src/Amqp/Akka.Streams.Amqp.V1/AmqpSinkStage.cs
+++ b/src/Amqp/Akka.Streams.Amqp.V1/AmqpSinkStage.cs
@@ -105,8 +105,13 @@ namespace Akka.Streams.Amqp.V1
             public override void PostStop()
             {
                 _sender?.Close();
-                _sender?.Session?.Close();
-                _sender?.Session?.Connection?.Close();
+
+                if(_stage.AmqpSourceSettings.ManageConnection)
+                {
+                    _sender?.Session?.Close();
+                    _sender?.Session?.Connection?.Close();
+                }
+
                 base.PostStop();
             }
         }

--- a/src/Amqp/Akka.Streams.Amqp.V1/AmqpSinkStage.cs
+++ b/src/Amqp/Akka.Streams.Amqp.V1/AmqpSinkStage.cs
@@ -1,11 +1,25 @@
 ﻿using Akka.Streams.Stage;
+﻿using System;
+using System.Collections.Generic;
 using Amqp;
 using System.Threading.Tasks;
+using Amqp.Framing;
 
 namespace Akka.Streams.Amqp.V1
 {
     public sealed class AmqpSinkStage<T> : GraphStageWithMaterializedValue<SinkShape<T>, Task>
     {
+        private static readonly Dictionary<int, TimeSpan> RetryInterval =
+            new Dictionary<int, TimeSpan>()
+            {
+                { 6, TimeSpan.FromMilliseconds(100) },
+                { 5, TimeSpan.FromMilliseconds(500) },
+                { 4, TimeSpan.FromMilliseconds(1000) },
+                { 3, TimeSpan.FromMilliseconds(2000) },
+                { 2, TimeSpan.FromMilliseconds(4000) },
+                { 1, TimeSpan.FromMilliseconds(8000) },
+            };
+
         public Inlet<T> In { get; }
         public override SinkShape<T> Shape { get; }
         public IAmqpSinkSettings<T> AmqpSourceSettings { get; }
@@ -28,13 +42,15 @@ namespace Akka.Streams.Amqp.V1
         {
             private readonly AmqpSinkStage<T> _stage;
             private readonly TaskCompletionSource<Done> _promise;
-            private readonly SenderLink _sender;
+            private readonly Action<(IAmqpObject, Error)> _disconnectedCallback;
+
+            private SenderLink _sender;
 
             public AmqpSinkStageLogic(AmqpSinkStage<T> amqpSinkStage, TaskCompletionSource<Done> promise, SinkShape<T> shape) : base(shape)
             {
                 _stage = amqpSinkStage;
                 _promise = promise;
-                _sender = amqpSinkStage.AmqpSourceSettings.GetSenderLink();
+                _disconnectedCallback = GetAsyncCallback<(IAmqpObject, Error)>(HandleDisconnection);
 
                 SetHandler(
                     inlet: _stage.In, 
@@ -49,15 +65,48 @@ namespace Akka.Streams.Amqp.V1
                 );
             }
 
+            private async Task Connect()
+            {
+                var retry = 5;
+                var exceptions = new List<Exception>();
+                while (true)
+                {
+                    try
+                    {
+                        _sender = _stage.AmqpSourceSettings.GetSenderLink();
+                        _sender.AddClosedCallback((sender, error) => _disconnectedCallback((sender, error)));
+                        Log.Info("Connected to AMQP.V1 server.");
+                        return;
+                    }
+                    catch (Exception e)
+                    {
+                        retry--;
+                        if (retry == 0)
+                            throw new AggregateException(exceptions);
+
+                        exceptions.Add(e);
+                        Log.Error($"[{retry}] more retries to connect to AMQP.V1 server.");
+                        await Task.Delay(RetryInterval[retry]);
+                    }
+                }
+            }
+
+            private void HandleDisconnection((IAmqpObject sender, Error error) args)
+                => FailStage(new DisconnectedException(args.sender, args.error));
+
             public override void PreStart()
             {
                 base.PreStart();
+
+                Connect().Wait();
                 Pull(_stage.In);
             }
 
             public override void PostStop()
             {
-                _sender.Close();
+                _sender?.Close();
+                _sender?.Session?.Close();
+                _sender?.Session?.Connection?.Close();
                 base.PostStop();
             }
         }

--- a/src/Amqp/Akka.Streams.Amqp.V1/AmqpSinkStage.cs
+++ b/src/Amqp/Akka.Streams.Amqp.V1/AmqpSinkStage.cs
@@ -67,7 +67,7 @@ namespace Akka.Streams.Amqp.V1
 
             private async Task Connect()
             {
-                var retry = 5;
+                var retry = 7;
                 var exceptions = new List<Exception>();
                 while (true)
                 {

--- a/src/Amqp/Akka.Streams.Amqp.V1/AmqpSinkStage.cs
+++ b/src/Amqp/Akka.Streams.Amqp.V1/AmqpSinkStage.cs
@@ -80,9 +80,15 @@ namespace Akka.Streams.Amqp.V1
                     }
                     catch (Exception e)
                     {
+                        if (!_stage.AmqpSourceSettings.ManageConnection && _sender.Session.IsClosed)
+                        {
+                            throw new ConnectionException(
+                                "Failed to connect to AMQP.V1 server. Could not retry connection because SinkSettings does not manage the Connection object.", e);
+                        }
+
                         retry--;
                         if (retry == 0)
-                            throw new AggregateException(exceptions);
+                            throw new AggregateException("Failed to connect to AMQP.V1 server.", exceptions);
 
                         exceptions.Add(e);
                         Log.Error($"[{retry}] more retries to connect to AMQP.V1 server.");

--- a/src/Amqp/Akka.Streams.Amqp.V1/AmqpSinkStage.cs
+++ b/src/Amqp/Akka.Streams.Amqp.V1/AmqpSinkStage.cs
@@ -80,7 +80,7 @@ namespace Akka.Streams.Amqp.V1
                     }
                     catch (Exception e)
                     {
-                        if (!_stage.AmqpSourceSettings.ManageConnection && _sender.Session.IsClosed)
+                        if (!_stage.AmqpSourceSettings.ManageConnection)
                         {
                             throw new ConnectionException(
                                 "Failed to connect to AMQP.V1 server. Could not retry connection because SinkSettings does not manage the Connection object.", e);
@@ -111,13 +111,6 @@ namespace Akka.Streams.Amqp.V1
             public override void PostStop()
             {
                 _sender?.Close();
-
-                if(_stage.AmqpSourceSettings.ManageConnection)
-                {
-                    _sender?.Session?.Close();
-                    _sender?.Session?.Connection?.Close();
-                }
-
                 base.PostStop();
             }
         }

--- a/src/Amqp/Akka.Streams.Amqp.V1/AmqpSourceStage.cs
+++ b/src/Amqp/Akka.Streams.Amqp.V1/AmqpSourceStage.cs
@@ -88,9 +88,15 @@ namespace Akka.Streams.Amqp.V1
                     }
                     catch (Exception e)
                     {
+                        if (!_stage.AmqpSourceSettings.ManageConnection && _receiver.Session.IsClosed)
+                        {
+                            throw new ConnectionException(
+                                "Failed to connect to AMQP.V1 server. Could not retry connection because SourceSettings does not manage the Connection object.", e);
+                        }
+
                         retry--;
                         if (retry == 0)
-                            throw new AggregateException(exceptions);
+                            throw new AggregateException("Failed to connect to AMQP.V1 server.", exceptions);
 
                         exceptions.Add(e);
                         Log.Error($"[{retry}] more retries to connect to AMQP.V1 server.");

--- a/src/Amqp/Akka.Streams.Amqp.V1/AmqpSourceStage.cs
+++ b/src/Amqp/Akka.Streams.Amqp.V1/AmqpSourceStage.cs
@@ -88,7 +88,7 @@ namespace Akka.Streams.Amqp.V1
                     }
                     catch (Exception e)
                     {
-                        if (!_stage.AmqpSourceSettings.ManageConnection && _receiver.Session.IsClosed)
+                        if (!_stage.AmqpSourceSettings.ManageConnection)
                         {
                             throw new ConnectionException(
                                 "Failed to connect to AMQP.V1 server. Could not retry connection because SourceSettings does not manage the Connection object.", e);
@@ -142,13 +142,6 @@ namespace Akka.Streams.Amqp.V1
             public override void PostStop()
             {
                 _receiver?.Close();
-
-                if(_stage.AmqpSourceSettings.ManageConnection)
-                {
-                    _receiver?.Session?.Close();
-                    _receiver?.Session?.Connection?.Close();
-                }
-
                 base.PostStop();
             }
         }

--- a/src/Amqp/Akka.Streams.Amqp.V1/AmqpSourceStage.cs
+++ b/src/Amqp/Akka.Streams.Amqp.V1/AmqpSourceStage.cs
@@ -136,8 +136,12 @@ namespace Akka.Streams.Amqp.V1
             public override void PostStop()
             {
                 _receiver?.Close();
-                _receiver?.Session?.Close();
-                _receiver?.Session?.Connection?.Close();
+
+                if(_stage.AmqpSourceSettings.ManageConnection)
+                {
+                    _receiver?.Session?.Close();
+                    _receiver?.Session?.Connection?.Close();
+                }
 
                 base.PostStop();
             }

--- a/src/Amqp/Akka.Streams.Amqp.V1/AmqpSourceStage.cs
+++ b/src/Amqp/Akka.Streams.Amqp.V1/AmqpSourceStage.cs
@@ -6,11 +6,23 @@ using Amqp.Framing;
 using Amqp.Types;
 using System;
 using System.Collections.Generic;
+using System.Threading.Tasks;
 
 namespace Akka.Streams.Amqp.V1
 {
     public sealed class AmqpSourceStage<T> : GraphStage<SourceShape<T>>
     {
+        private static readonly Dictionary<int, TimeSpan> RetryInterval =
+            new Dictionary<int, TimeSpan>()
+            {
+                { 6, TimeSpan.FromMilliseconds(100) },
+                { 5, TimeSpan.FromMilliseconds(500) },
+                { 4, TimeSpan.FromMilliseconds(1000) },
+                { 3, TimeSpan.FromMilliseconds(2000) },
+                { 2, TimeSpan.FromMilliseconds(4000) },
+                { 1, TimeSpan.FromMilliseconds(8000) },
+            };
+
         public override SourceShape<T> Shape { get; }
         public Outlet<T> Out { get; }
         public IAmqpSourceSettings<T> AmqpSourceSettings { get; }
@@ -25,18 +37,24 @@ namespace Akka.Streams.Amqp.V1
 
         private class AmqpSourceStageLogic : GraphStageLogic
         {
+            private readonly AmqpSourceStage<T> _stage;
             private readonly Outlet<T> _outlet;
             private readonly IAmqpSourceSettings<T> _amqpSourceSettings;
-            private readonly ReceiverLink _receiver;
             private readonly Decider _decider;
             private readonly Queue<Message> _queue = new Queue<Message>();
+            private readonly Action<(IAmqpObject, Error)> _disconnectedCallback;
+            private readonly Action<Message> _consumerCallback;
+
+            private ReceiverLink _receiver;
 
             public AmqpSourceStageLogic(AmqpSourceStage<T> stage, Attributes attributes) : base(stage.Shape)
             {
+                _stage = stage;
                 _outlet = stage.Out;
                 _amqpSourceSettings = stage.AmqpSourceSettings;
-                _receiver = stage.AmqpSourceSettings.GetReceiverLink();
                 _decider = attributes.GetDeciderOrDefault();
+                _disconnectedCallback = GetAsyncCallback<(IAmqpObject, Error)>(HandleDisconnection);
+                _consumerCallback = GetAsyncCallback<Message>(HandleDelivery);
 
                 SetHandler(_outlet, () =>
                 {
@@ -51,9 +69,38 @@ namespace Akka.Streams.Amqp.V1
             {
                 base.PreStart();
 
-                var consumerCallback = GetAsyncCallback<Message>(HandleDelivery);
-                _receiver.Start(_amqpSourceSettings.Credit, (_, m) => consumerCallback.Invoke(m));
+                Connect().Wait();
             }
+
+            private async Task Connect()
+            {
+                var retry = 5;
+                var exceptions = new List<Exception>();
+                while (true)
+                {
+                    try
+                    {
+                        _receiver = _stage.AmqpSourceSettings.GetReceiverLink();
+                        _receiver.AddClosedCallback((sender, error) => _disconnectedCallback((sender, error)));
+                        _receiver.Start(_amqpSourceSettings.Credit, (_, m) => _consumerCallback.Invoke(m));
+                        Log.Info("Connected to AMQP.V1 server.");
+                        return;
+                    }
+                    catch (Exception e)
+                    {
+                        retry--;
+                        if (retry == 0)
+                            throw new AggregateException(exceptions);
+
+                        exceptions.Add(e);
+                        Log.Error($"[{retry}] more retries to connect to AMQP.V1 server.");
+                        await Task.Delay(RetryInterval[retry]);
+                    }
+                }
+            }
+
+            private void HandleDisconnection((IAmqpObject sender, Error error) args)
+                => FailStage(new DisconnectedException(args.sender, args.error));
 
             private void HandleDelivery(Message message)
             {
@@ -88,7 +135,10 @@ namespace Akka.Streams.Amqp.V1
 
             public override void PostStop()
             {
-                _receiver.Close();
+                _receiver?.Close();
+                _receiver?.Session?.Close();
+                _receiver?.Session?.Connection?.Close();
+
                 base.PostStop();
             }
         }

--- a/src/Amqp/Akka.Streams.Amqp.V1/AmqpSourceStage.cs
+++ b/src/Amqp/Akka.Streams.Amqp.V1/AmqpSourceStage.cs
@@ -74,7 +74,7 @@ namespace Akka.Streams.Amqp.V1
 
             private async Task Connect()
             {
-                var retry = 5;
+                var retry = 7;
                 var exceptions = new List<Exception>();
                 while (true)
                 {

--- a/src/Amqp/Akka.Streams.Amqp.V1/DisconnectedException.cs
+++ b/src/Amqp/Akka.Streams.Amqp.V1/DisconnectedException.cs
@@ -1,0 +1,20 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using Amqp;
+using Amqp.Framing;
+
+namespace Akka.Streams.Amqp.V1
+{
+    public class DisconnectedException : Exception
+    {
+        public IAmqpObject Sender { get; }
+        public Error Error { get; }
+
+        public DisconnectedException(IAmqpObject sender, Error error) : base(error.Description)
+        {
+            Sender = sender;
+            Error = error;
+        }
+    }
+}

--- a/src/Amqp/Akka.Streams.Amqp.V1/IAmqpSinkSettings.cs
+++ b/src/Amqp/Akka.Streams.Amqp.V1/IAmqpSinkSettings.cs
@@ -1,4 +1,5 @@
-﻿using Akka.IO;
+﻿using System.Threading.Tasks;
+using Akka.IO;
 using Amqp;
 
 namespace Akka.Streams.Amqp.V1
@@ -8,5 +9,8 @@ namespace Akka.Streams.Amqp.V1
         bool ManageConnection { get; }
         SenderLink GetSenderLink();
         byte[] GetBytes(T obj);
+
+        void CloseConnection();
+        Task CloseConnectionAsync();
     }
 }

--- a/src/Amqp/Akka.Streams.Amqp.V1/IAmqpSinkSettings.cs
+++ b/src/Amqp/Akka.Streams.Amqp.V1/IAmqpSinkSettings.cs
@@ -5,6 +5,7 @@ namespace Akka.Streams.Amqp.V1
 {
     public interface IAmqpSinkSettings<in T>
     {
+        bool ManageConnection { get; }
         SenderLink GetSenderLink();
         byte[] GetBytes(T obj);
     }

--- a/src/Amqp/Akka.Streams.Amqp.V1/IAmqpSourceSettings.cs
+++ b/src/Amqp/Akka.Streams.Amqp.V1/IAmqpSourceSettings.cs
@@ -6,6 +6,7 @@ namespace Akka.Streams.Amqp.V1
     {
         ReceiverLink GetReceiverLink();
         int Credit { get; }
+        bool ManageConnection { get; }
         T Convert(Message message);
     }
 }

--- a/src/Amqp/Akka.Streams.Amqp.V1/IAmqpSourceSettings.cs
+++ b/src/Amqp/Akka.Streams.Amqp.V1/IAmqpSourceSettings.cs
@@ -1,4 +1,5 @@
-﻿using Amqp;
+﻿using System.Threading.Tasks;
+using Amqp;
 
 namespace Akka.Streams.Amqp.V1
 {
@@ -8,5 +9,8 @@ namespace Akka.Streams.Amqp.V1
         int Credit { get; }
         bool ManageConnection { get; }
         T Convert(Message message);
+
+        void CloseConnection();
+        Task CloseConnectionAsync();
     }
 }

--- a/src/Amqp/Akka.Streams.Amqp.V1/NamedQueueSinkSettings.cs
+++ b/src/Amqp/Akka.Streams.Amqp.V1/NamedQueueSinkSettings.cs
@@ -13,6 +13,8 @@ namespace Akka.Streams.Amqp.V1
         private readonly string _queueName;
         private readonly Serializer _serializer;
 
+        public bool ManageConnection => false;
+
         public NamedQueueSinkSettings(
             Session session,
             string linkName,

--- a/src/Amqp/Akka.Streams.Amqp.V1/NamedQueueSinkSettings.cs
+++ b/src/Amqp/Akka.Streams.Amqp.V1/NamedQueueSinkSettings.cs
@@ -1,4 +1,6 @@
-﻿using Akka.IO;
+﻿using System;
+using System.Threading.Tasks;
+using Akka.IO;
 using Amqp;
 using Akka.Serialization;
 using Amqp.Framing;
@@ -15,6 +17,8 @@ namespace Akka.Streams.Amqp.V1
 
         public bool ManageConnection => false;
 
+        public bool IsClosed => _session?.IsClosed ?? true;
+
         public NamedQueueSinkSettings(
             Session session,
             string linkName,
@@ -30,6 +34,18 @@ namespace Akka.Streams.Amqp.V1
         public byte[] GetBytes(T obj)
         {
             return _serializer.ToBinary(obj);
+        }
+
+        public void CloseConnection()
+        {
+            _session.Close();
+            _session.Connection.Close();
+        }
+
+        public async Task CloseConnectionAsync()
+        {
+            await _session.CloseAsync();
+            await _session.Connection.CloseAsync();
         }
 
         public SenderLink GetSenderLink() => new SenderLink(_session, _linkName, new Target

--- a/src/Amqp/Akka.Streams.Amqp.V1/NamedQueueSourceSettings.cs
+++ b/src/Amqp/Akka.Streams.Amqp.V1/NamedQueueSourceSettings.cs
@@ -12,6 +12,8 @@ namespace Akka.Streams.Amqp.V1
         private readonly string _queueName;
         private readonly Serializer _serializer;
 
+        public bool ManageConnection => false;
+
         public NamedQueueSourceSettings(
             Session session,
             string linkName,

--- a/src/Amqp/Akka.Streams.Amqp.V1/NamedQueueSourceSettings.cs
+++ b/src/Amqp/Akka.Streams.Amqp.V1/NamedQueueSourceSettings.cs
@@ -1,4 +1,5 @@
-﻿using Akka.Serialization;
+﻿using System.Threading.Tasks;
+using Akka.Serialization;
 using Amqp;
 using Amqp.Framing;
 using Amqp.Types;
@@ -13,6 +14,8 @@ namespace Akka.Streams.Amqp.V1
         private readonly Serializer _serializer;
 
         public bool ManageConnection => false;
+
+        public bool IsClosed => _session?.IsClosed ?? true;
 
         public NamedQueueSourceSettings(
             Session session,
@@ -32,6 +35,18 @@ namespace Akka.Streams.Amqp.V1
         {
             var bString = message.GetBody<byte[]>();
             return _serializer.FromBinary<T>(bString);
+        }
+
+        public void CloseConnection()
+        {
+            _session.Close();
+            _session.Connection.Close();
+        }
+
+        public async Task CloseConnectionAsync()
+        {
+            await _session.CloseAsync();
+            await _session.Connection.CloseAsync();
         }
 
         public int Credit { get; }

--- a/src/Amqp/Examples/Amqp.V1.Sink/Amqp.V1.Sink.csproj
+++ b/src/Amqp/Examples/Amqp.V1.Sink/Amqp.V1.Sink.csproj
@@ -3,6 +3,7 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>netcoreapp3.1</TargetFramework>
+    <IsPackable>false</IsPackable>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Amqp/Examples/Amqp.V1.Sink/Amqp.V1.Sink.csproj
+++ b/src/Amqp/Examples/Amqp.V1.Sink/Amqp.V1.Sink.csproj
@@ -1,0 +1,12 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\Akka.Streams.Amqp.V1\Akka.Streams.Amqp.V1.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/src/Amqp/Examples/Amqp.V1.Sink/Program.cs
+++ b/src/Amqp/Examples/Amqp.V1.Sink/Program.cs
@@ -3,6 +3,7 @@ using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 using Akka.Actor;
+using Akka.Serialization;
 using Akka.Streams;
 using Akka.Streams.Amqp.V1;
 using Akka.Streams.Amqp.V1.Dsl;
@@ -12,23 +13,37 @@ namespace Amqp.V1.Sink
 {
     class Program
     {
+        private const string QueueName = "akka.test";
+        private const string SenderLinkName = "amqp-conn-test-sender";
+
+        private static ActorSystem _system;
+        private static ActorMaterializer _materializer;
+        private static Serializer _serializer;
+        private static Address _address;
+
         static async Task Main(string[] args)
         {
-            var sys = ActorSystem.Create("AMQP-System-Sink");
-            var materializer = ActorMaterializer.Create(sys);
-            var serialization = sys.Serialization;
-            var serializer = serialization.FindSerializerForType(typeof(string));
+            _system = ActorSystem.Create("AMQP-System-Sink");
+            _materializer = ActorMaterializer.Create(_system);
+            var serialization = _system.Serialization;
+            _serializer = serialization.FindSerializerForType(typeof(string));
+            _address = new Address("127.0.0.1", 5672, "guest", "guest", scheme: "AMQP");
 
-            var address = new Address("127.0.0.1", 5672, "guest", "guest", scheme: "AMQP");
+            await UsingAddressSink();
 
-            var queueName = "akka.test";
-            var senderLinkName = "amqp-conn-test-sender";
+            await _system.Terminate();
+        }
 
+        // The settings object manages the Session and Connection object
+        private static async Task UsingAddressSink()
+        {
+            var settings = new AddressSinkSettings<string>(_address, SenderLinkName, QueueName, _serializer);
+
+            // create sink
             var amqpSink = RestartSink.WithBackoff(() =>
                 {
                     Console.WriteLine("Start/Restart...");
-                    return AmqpSink.Create(
-                        new AddressSinkSettings<string>(address, senderLinkName, queueName, serializer));
+                    return AmqpSink.Create(settings);
                 },
                 TimeSpan.FromSeconds(1),
                 TimeSpan.FromSeconds(3),
@@ -46,11 +61,66 @@ namespace Amqp.V1.Sink
                     Console.WriteLine(s);
                     return s;
                 })
-                .RunWith(amqpSink, materializer);
+                .RunWith(amqpSink, _materializer);
 
             Console.ReadKey();
 
-            await sys.Terminate();
+            await settings.CloseConnectionAsync();
+        }
+
+        // The user manages the Session and Connection object
+        private static async Task UsingNamedQueueSink()
+        {
+            Connection connection = null;
+            Session session = null;
+
+            // create sink
+            var amqpSink = RestartSink.WithBackoff(() =>
+                {
+                    Console.WriteLine("Start/Restart...");
+                    try
+                    {
+                        if (connection == null || connection.IsClosed)
+                            connection = new Connection(_address);
+
+                        if (session == null || session.IsClosed)
+                            session = new Session(connection);
+                    }
+                    catch
+                    {
+                        connection?.Close();
+                        session?.Close();
+
+                        connection = null;
+                        session = null;
+                    }
+
+                    return AmqpSink.Create(new NamedQueueSinkSettings<string>(session, SenderLinkName, QueueName, _serializer));
+                },
+                TimeSpan.FromSeconds(1),
+                TimeSpan.FromSeconds(3),
+                0.2,
+                short.MaxValue
+            );
+
+            //run sink
+            var input = new[] { "one", "two", "three", "four", "five" };
+            Source
+                .Cycle(() => input.AsEnumerable().GetEnumerator())
+                .Delay(TimeSpan.FromSeconds(1))
+                .Select(s =>
+                {
+                    Console.WriteLine(s);
+                    return s;
+                })
+                .RunWith(amqpSink, _materializer);
+
+            Console.ReadKey();
+
+            if (session != null)
+                await session.CloseAsync();
+            if (connection != null)
+                await connection.CloseAsync();
         }
     }
 }

--- a/src/Amqp/Examples/Amqp.V1.Sink/Program.cs
+++ b/src/Amqp/Examples/Amqp.V1.Sink/Program.cs
@@ -1,0 +1,56 @@
+﻿using System;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Akka.Actor;
+using Akka.Streams;
+using Akka.Streams.Amqp.V1;
+using Akka.Streams.Amqp.V1.Dsl;
+using Akka.Streams.Dsl;
+
+namespace Amqp.V1.Sink
+{
+    class Program
+    {
+        static async Task Main(string[] args)
+        {
+            var sys = ActorSystem.Create("AMQP-System-Sink");
+            var materializer = ActorMaterializer.Create(sys);
+            var serialization = sys.Serialization;
+            var serializer = serialization.FindSerializerForType(typeof(string));
+
+            var address = new Address("127.0.0.1", 5672, "guest", "guest", scheme: "AMQP");
+
+            var queueName = "akka.test";
+            var senderLinkName = "amqp-conn-test-sender";
+
+            var amqpSink = RestartSink.WithBackoff(() =>
+                {
+                    Console.WriteLine("Start/Restart...");
+                    return AmqpSink.Create(
+                        new AddressSinkSettings<string>(address, senderLinkName, queueName, serializer));
+                },
+                TimeSpan.FromSeconds(1),
+                TimeSpan.FromSeconds(3),
+                0.2,
+                short.MaxValue
+            );
+
+            //run sink
+            var input = new[] { "one", "two", "three", "four", "five" };
+            Source
+                .Cycle(() => input.AsEnumerable().GetEnumerator())
+                .Delay(TimeSpan.FromSeconds(1))
+                .Select(s =>
+                {
+                    Console.WriteLine(s);
+                    return s;
+                })
+                .RunWith(amqpSink, materializer);
+
+            Console.ReadKey();
+
+            await sys.Terminate();
+        }
+    }
+}

--- a/src/Amqp/Examples/Amqp.V1.Source/Amqp.V1.Source.csproj
+++ b/src/Amqp/Examples/Amqp.V1.Source/Amqp.V1.Source.csproj
@@ -3,6 +3,7 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>netcoreapp3.1</TargetFramework>
+    <IsPackable>false</IsPackable>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Amqp/Examples/Amqp.V1.Source/Amqp.V1.Source.csproj
+++ b/src/Amqp/Examples/Amqp.V1.Source/Amqp.V1.Source.csproj
@@ -1,0 +1,12 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\Akka.Streams.Amqp.V1\Akka.Streams.Amqp.V1.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/src/Amqp/Examples/Amqp.V1.Source/Program.cs
+++ b/src/Amqp/Examples/Amqp.V1.Source/Program.cs
@@ -1,0 +1,47 @@
+﻿using System;
+using System.Text;
+using System.Threading.Tasks;
+using Akka.Actor;
+using Akka.Streams;
+using Akka.Streams.Amqp.V1;
+using Akka.Streams.Amqp.V1.Dsl;
+using Akka.Streams.Dsl;
+
+namespace Amqp.V1.Source
+{
+    class Program
+    {
+        static async Task Main(string[] args)
+        {
+            var sys = ActorSystem.Create("AMQP-System-Source");
+            var materializer = ActorMaterializer.Create(sys);
+            var serialization = sys.Serialization;
+            var serializer = serialization.FindSerializerForType(typeof(string));
+
+            var address = new Address("127.0.0.1", 5672, "guest", "guest", scheme: "AMQP");
+
+            var queueName = "akka.test";
+            var receiverLinkName = "amqp-conn-test-receiver";
+
+            //create source
+            var amqpSource = RestartSource.OnFailuresWithBackoff(
+                () => {
+                    Console.WriteLine("Start/Restart...");
+                    return AmqpSource
+                        .Create(new AddressSourceSettings<string>(address, receiverLinkName, queueName, 200, serializer));
+                },
+                TimeSpan.FromSeconds(1),
+                TimeSpan.FromSeconds(3),
+                0.2,
+                short.MaxValue
+            );
+
+            //run source
+            await amqpSource
+                .Throttle(1, TimeSpan.FromSeconds(1), 10, ThrottleMode.Shaping)
+                .RunForeach(Console.WriteLine, materializer);
+
+            await sys.Terminate();
+        }
+    }
+}

--- a/src/Amqp/Examples/Amqp.V1.Source/Program.cs
+++ b/src/Amqp/Examples/Amqp.V1.Source/Program.cs
@@ -1,7 +1,9 @@
 ﻿using System;
+using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 using Akka.Actor;
+using Akka.Serialization;
 using Akka.Streams;
 using Akka.Streams.Amqp.V1;
 using Akka.Streams.Amqp.V1.Dsl;
@@ -11,24 +13,37 @@ namespace Amqp.V1.Source
 {
     class Program
     {
+        private const string QueueName = "akka.test";
+        private const string ReceiverLinkName = "amqp-conn-test-sender";
+
+        private static ActorSystem _system;
+        private static ActorMaterializer _materializer;
+        private static Serializer _serializer;
+        private static Address _address;
+
         static async Task Main(string[] args)
         {
-            var sys = ActorSystem.Create("AMQP-System-Source");
-            var materializer = ActorMaterializer.Create(sys);
-            var serialization = sys.Serialization;
-            var serializer = serialization.FindSerializerForType(typeof(string));
+            _system = ActorSystem.Create("AMQP-System-Source");
+            _materializer = ActorMaterializer.Create(_system);
+            var serialization = _system.Serialization;
+            _serializer = serialization.FindSerializerForType(typeof(string));
+            _address = new Address("127.0.0.1", 5672, "guest", "guest", scheme: "AMQP");
 
-            var address = new Address("127.0.0.1", 5672, "guest", "guest", scheme: "AMQP");
+            await UsingAddressSource();
 
-            var queueName = "akka.test";
-            var receiverLinkName = "amqp-conn-test-receiver";
+            await _system.Terminate();
+        }
+
+        // The settings object manages the Session and Connection object
+        private static async Task UsingAddressSource()
+        {
+            var settings = new AddressSourceSettings<string>(_address, ReceiverLinkName, QueueName, 200, _serializer);
 
             //create source
             var amqpSource = RestartSource.OnFailuresWithBackoff(
                 () => {
                     Console.WriteLine("Start/Restart...");
-                    return AmqpSource
-                        .Create(new AddressSourceSettings<string>(address, receiverLinkName, queueName, 200, serializer));
+                    return AmqpSource.Create(settings);
                 },
                 TimeSpan.FromSeconds(1),
                 TimeSpan.FromSeconds(3),
@@ -39,9 +54,58 @@ namespace Amqp.V1.Source
             //run source
             await amqpSource
                 .Throttle(1, TimeSpan.FromSeconds(1), 10, ThrottleMode.Shaping)
-                .RunForeach(Console.WriteLine, materializer);
+                .RunForeach(Console.WriteLine, _materializer);
 
-            await sys.Terminate();
+            Console.ReadKey();
+
+            await settings.CloseConnectionAsync();
+        }
+
+        // The user manages the Session and Connection object
+        private static async Task UsingNamedQueueSource()
+        {
+            Connection connection = null;
+            Session session = null;
+
+            var amqpSource = RestartSource.WithBackoff(() =>
+            {
+                Console.WriteLine("Start/Restart...");
+                try
+                {
+                    if (connection == null || connection.IsClosed)
+                        connection = new Connection(_address);
+
+                    if (session == null || session.IsClosed)
+                        session = new Session(connection);
+                }
+                catch
+                {
+                    connection?.Close();
+                    session?.Close();
+
+                    connection = null;
+                    session = null;
+                }
+
+                return AmqpSource.Create(new NamedQueueSourceSettings<string>(session, ReceiverLinkName, QueueName, 200, _serializer));
+            },
+                TimeSpan.FromSeconds(1),
+                TimeSpan.FromSeconds(3),
+                0.2,
+                short.MaxValue
+            );
+
+            //run source
+            await amqpSource
+                .Throttle(1, TimeSpan.FromSeconds(1), 10, ThrottleMode.Shaping)
+                .RunForeach(Console.WriteLine, _materializer);
+
+            Console.ReadKey();
+
+            if (session != null)
+                await session.CloseAsync();
+            if (connection != null)
+                await connection.CloseAsync();
         }
     }
 }


### PR DESCRIPTION
Closes #288

Adds settings variant that's able to manage the `Connection` and `Session` states so that it plays nice with disconnection/reconnection; all the user need to do is provide the `Address` object.