### PR TITLE
Removed dependency on WindowsAzure.ServiceBus in favour of Azure.Messaging.ServiceBus

### DIFF
--- a/src/Azure/Akka.Streams.Azure.ServiceBus/Akka.Streams.Azure.ServiceBus.csproj
+++ b/src/Azure/Akka.Streams.Azure.ServiceBus/Akka.Streams.Azure.ServiceBus.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
     <Import Project="..\..\common.props" />
 
     <PropertyGroup>
@@ -11,7 +11,7 @@
 
     <ItemGroup>
         <PackageReference Include="Akka.Streams" Version="$(AkkaVersion)" />
-        <PackageReference Include="WindowsAzure.ServiceBus" Version="6.0.3" />
+        <PackageReference Include="Azure.Messaging.ServiceBus" Version="7.1.0" />
     </ItemGroup>
 
 </Project>

--- a/src/Azure/Akka.Streams.Azure.ServiceBus/SourceExtension.cs
+++ b/src/Azure/Akka.Streams.Azure.ServiceBus/SourceExtension.cs
@@ -1,7 +1,7 @@
 ﻿using System.Collections.Generic;
 using System.Threading.Tasks;
 using Akka.Streams.Dsl;
-using Microsoft.ServiceBus.Messaging;
+using Azure.Messaging.ServiceBus;
 
 namespace Akka.Streams.Azure.ServiceBus
 {
@@ -12,17 +12,7 @@ namespace Akka.Streams.Azure.ServiceBus
         /// The returned <see cref="Task"/> will be completed with Success when reaching the
         /// normal end of the stream, or completed with Failure if there is a failure signaled in the stream.
         /// </summary>
-        public static Task ToServiceBus<TMat>(this Source<IEnumerable<BrokeredMessage>, TMat> source, QueueClient client, IMaterializer materializer)
-        {
-            return source.RunWith(new ServiceBusSink(client), materializer);
-        }
-
-        /// <summary>
-        /// Shurtcut for running this <see cref="Source{TOut,TMat}"/> with a <see cref="ServiceBusSink"/>.
-        /// The returned <see cref="Task"/> will be completed with Success when reaching the
-        /// normal end of the stream, or completed with Failure if there is a failure signaled in the stream.
-        /// </summary>
-        public static Task ToServiceBus<TMat>(this Source<IEnumerable<BrokeredMessage>, TMat> source, TopicClient client, IMaterializer materializer)
+        public static Task ToServiceBus<TMat>(this Source<IEnumerable<ServiceBusMessage>, TMat> source, ServiceBusSender client, IMaterializer materializer)
         {
             return source.RunWith(new ServiceBusSink(client), materializer);
         }

--- a/src/Azure/Examples/Akka.Streams.Azure.ServiceBus.Examples/Program.cs
+++ b/src/Azure/Examples/Akka.Streams.Azure.ServiceBus.Examples/Program.cs
@@ -1,33 +1,39 @@
 ﻿using System;
 using System.Linq;
+using System.Text;
 using Akka.Actor;
 using Akka.Streams.Dsl;
-using Microsoft.ServiceBus.Messaging;
+using Azure.Messaging.ServiceBus;
 
 namespace Akka.Streams.Azure.ServiceBus.Examples
 {
     class Program
     {
-        private const string ConnectionString = "{ServiceBus connection string}";
-        private const string QueueName = "{ServiceBus queue name}";
+        private const string ConnectionString = "[Azure service bus connection string]";
+        private const string QueueOrTopicName = "[Azure service bus queue or topic name]";
+        private const string SubscriptionName = "[Azure service bus subscription name]";
 
         static void Main()
         {
-            var client = QueueClient.CreateFromConnectionString(ConnectionString, QueueName);
+            var client = new ServiceBusClient(ConnectionString);
+            var receiveClient = client.CreateReceiver(QueueOrTopicName);
+            // To use a subscription:
+            // var receiveClient = client.CreateReceiver(QueueOrTopicName, SubscriptionName);
+            var senderClient = client.CreateSender(QueueOrTopicName);
 
             using var sys = ActorSystem.Create("ServiceBusSystem");
             using var mat = sys.Materializer();
 
             Console.WriteLine("Writing messages into the queue");
             var t = Source.From(Enumerable.Range(1,100))
-                .Select(x => new BrokeredMessage("Message: " + x))
+                .Select(x => new ServiceBusMessage("Sending Message: " + x))
                 .Grouped(10)
-                .ToServiceBus(client, mat);
+                .ToServiceBus(senderClient, mat);
             t.Wait();
             Console.WriteLine("Finished ");
 
             Console.WriteLine("Reading messages from the queue");
-            t = ServiceBusSource.Create<string>(client).RunForeach(Console.WriteLine, mat);
+            t = ServiceBusSource.Create<string>(receiveClient, msg => Encoding.UTF8.GetString(msg.Body.ToArray())).RunForeach(x => Console.WriteLine("Received {0}", x), mat);
                   
             Console.WriteLine("Press any key to exit");
             Console.ReadKey();


### PR DESCRIPTION
WindowsAzure.ServiceBus needs .NET FX 4.6/4.7 and thus not cross platform.
Changed the package to use the newer .NET Standard 2.0 library Azure.Messaging.ServiceBus.

Removed Topic and Subscription wrappers as these are now handled directly by the ServiceBusReceiver client passed into the ServiceBusSource