### PR TITLE
Update ASP.NET SignalR to netcoreapp3.1

### DIFF
--- a/build-system/azure-pipeline.template.yaml
+++ b/build-system/azure-pipeline.template.yaml
@@ -30,6 +30,11 @@ jobs:
         inputs:
           packageType: sdk
           version: 5.0.101
+      - task: UseDotNet@2
+        displayName: 'Use .NET Core Runtime 3.1.10'
+        inputs:
+          packageType: runtime
+          version: 3.1.10
 
       # Linux
       # Do build

--- a/build-system/azure-pipeline.template.yaml
+++ b/build-system/azure-pipeline.template.yaml
@@ -30,11 +30,6 @@ jobs:
         inputs:
           packageType: sdk
           version: 5.0.101
-      - task: UseDotNet@2
-        displayName: 'Use .NET Core Runtime 3.1.10'
-        inputs:
-          packageType: runtime
-          version: 3.1.10
 
       # Linux
       # Do build

--- a/build-system/azure-pipeline.template.yaml
+++ b/build-system/azure-pipeline.template.yaml
@@ -26,10 +26,10 @@ jobs:
         persistCredentials: true
 
       - task: UseDotNet@2
-        displayName: 'Use .NET Core SDK 3.1.105'
+        displayName: 'Use .NET 5 SDK 5.0.101'
         inputs:
           packageType: sdk
-          version: 3.1.105
+          version: 5.0.101
 
       # Linux
       # Do build

--- a/build-system/azure-pipeline.template.yaml
+++ b/build-system/azure-pipeline.template.yaml
@@ -26,10 +26,10 @@ jobs:
         persistCredentials: true
 
       - task: UseDotNet@2
-        displayName: 'Use .NET 5 SDK 5.0.101'
+        displayName: 'Use .NET Core SDK 3.1.105'
         inputs:
           packageType: sdk
-          version: 5.0.101
+          version: 3.1.105
 
       # Linux
       # Do build

--- a/src/SignalR.AspNetCore/Akka.Streams.SignalR.AspNetCore.Tests/Akka.Streams.SignalR.AspNetCore.Tests.csproj
+++ b/src/SignalR.AspNetCore/Akka.Streams.SignalR.AspNetCore.Tests/Akka.Streams.SignalR.AspNetCore.Tests.csproj
@@ -2,7 +2,7 @@
     <Import Project="..\..\common.props" />
 
     <PropertyGroup>
-        <TargetFrameworks>$(NetCoreTestVersion);net5</TargetFrameworks>
+        <TargetFramework>$(NetCoreTestVersion)</TargetFramework>
         <IsPackable>false</IsPackable>
     </PropertyGroup>
 

--- a/src/SignalR.AspNetCore/Akka.Streams.SignalR.AspNetCore.Tests/Akka.Streams.SignalR.AspNetCore.Tests.csproj
+++ b/src/SignalR.AspNetCore/Akka.Streams.SignalR.AspNetCore.Tests/Akka.Streams.SignalR.AspNetCore.Tests.csproj
@@ -2,7 +2,7 @@
     <Import Project="..\..\common.props" />
 
     <PropertyGroup>
-        <TargetFrameworks>$(NetCoreTestVersion)</TargetFrameworks>
+        <TargetFrameworks>$(NetCoreTestVersion);net5</TargetFrameworks>
         <IsPackable>false</IsPackable>
     </PropertyGroup>
 

--- a/src/SignalR.AspNetCore/Akka.Streams.SignalR.AspNetCore/Akka.Streams.SignalR.AspNetCore.csproj
+++ b/src/SignalR.AspNetCore/Akka.Streams.SignalR.AspNetCore/Akka.Streams.SignalR.AspNetCore.csproj
@@ -4,13 +4,13 @@
     <PropertyGroup>
         <AssemblyTitle>Akka.Streams.SignalR.AspNetCore</AssemblyTitle>
         <Description>SignalR ASP.Net Core connector for Akka.NET Streams</Description>
-        <TargetFramework>$(NetStandardLibVersion)</TargetFramework>
+        <TargetFrameworks>netcoreapp3.1;net5</TargetFrameworks>
         <PackageTags>$(AkkaPackageTags);signalr</PackageTags>
     </PropertyGroup>
 
     <ItemGroup>
         <PackageReference Include="Akka.Streams" Version="$(AkkaVersion)" />
-        <PackageReference Include="microsoft.aspnetcore.signalr" Version="1.1.0" />
+        <FrameworkReference Include="Microsoft.AspNetCore.App" />
     </ItemGroup>
 
     <ItemGroup>

--- a/src/SignalR.AspNetCore/Akka.Streams.SignalR.AspNetCore/Akka.Streams.SignalR.AspNetCore.csproj
+++ b/src/SignalR.AspNetCore/Akka.Streams.SignalR.AspNetCore/Akka.Streams.SignalR.AspNetCore.csproj
@@ -4,7 +4,7 @@
     <PropertyGroup>
         <AssemblyTitle>Akka.Streams.SignalR.AspNetCore</AssemblyTitle>
         <Description>SignalR ASP.Net Core connector for Akka.NET Streams</Description>
-        <TargetFrameworks>netcoreapp3.1;net5</TargetFrameworks>
+        <TargetFramework>netcoreapp3.1</TargetFramework>
         <PackageTags>$(AkkaPackageTags);signalr</PackageTags>
     </PropertyGroup>
 


### PR DESCRIPTION
Closes #635 

Microsoft has deprecated .NET Standard for SignalR builds, the latest nuget package version we can use for .NET Standard for Microsoft.AspNetCore.SignalR was version 1.1.0 from 3 years ago.

To update SignalR, we have to use .NET Core 3.1 and target netcoreapp3.1 and Microsoft.AspNetCore.App framework instead. This framework contains Microsoft.AspNetCore.SignalR 3.1.0.0 that is not released as a nuget package.