### PR TITLE
Fix typo with the `TimerKey`

### DIFF
--- a/src/AWS/Kinesis/Akka.Streams.Kinesis.Tests/KinesisSourceSpec.cs
+++ b/src/AWS/Kinesis/Akka.Streams.Kinesis.Tests/KinesisSourceSpec.cs
@@ -110,7 +110,48 @@ namespace Akka.Streams.Kinesis.Tests
             probe.ExpectNext("a");
             probe.ExpectNext("b");
         }
+        [Fact]
+        public void KinesisSource_must_poll_for_batched_records_with_multiple_requests()
+        {
+            var data = new[] { "a", "b" };
+            WithGetShardIteratorSuccess();
+            WithGetRecordsSuccess(data);
 
+            var probe = this.CreateManualSubscriberProbe<string>();
+            KinesisSource.Basic(_settings, () => _kinesisClient)
+                .Select(x => Encoding.UTF8.GetString(x.Data.ToArray()))
+                .To(Sink.FromSubscriber(probe))
+                .Run(_materializer);
+
+            var subscription = probe.ExpectSubscription();
+
+            subscription.Request(2);
+            probe.ExpectNext("a");
+            probe.ExpectNext("b");
+
+            probe.ExpectNoMsg(1.Seconds());
+
+            subscription.Request(2);
+            probe.ExpectNext("a");
+            probe.ExpectNext("b");
+
+            var data2 = new[] { "c", "d" };
+            WithGetRecordsSuccess(data2);
+            subscription.Request(4);
+            probe.ExpectNext("a");
+            probe.ExpectNext("b");
+            probe.ExpectNext("c");
+            probe.ExpectNext("d");
+
+            probe.ExpectNoMsg(1.Seconds());
+
+
+            subscription.Request(4);
+            probe.ExpectNext("a");
+            probe.ExpectNext("b");
+            probe.ExpectNext("c");
+            probe.ExpectNext("d");
+        }
         [Fact]
         public void KinesisSource_must_wait_for_request_before_passing_downstream()
         {

--- a/src/AWS/Kinesis/Akka.Streams.Kinesis.Tests/KinesisSourceSpec.cs
+++ b/src/AWS/Kinesis/Akka.Streams.Kinesis.Tests/KinesisSourceSpec.cs
@@ -146,9 +146,7 @@ namespace Akka.Streams.Kinesis.Tests
             probe.ExpectNoMsg(1.Seconds());
 
 
-            subscription.Request(4);
-            probe.ExpectNext("a");
-            probe.ExpectNext("b");
+            subscription.Request(2);
             probe.ExpectNext("c");
             probe.ExpectNext("d");
         }

--- a/src/AWS/Kinesis/Akka.Streams.Kinesis/Akka.Streams.Kinesis.csproj
+++ b/src/AWS/Kinesis/Akka.Streams.Kinesis/Akka.Streams.Kinesis.csproj
@@ -4,7 +4,7 @@
     <PropertyGroup>
         <AssemblyTitle>Akka.Streams.Kinesis</AssemblyTitle>
         <Description>AWS Kinesis adapter for Akka.NET Streams</Description>
-        <TargetFramework>net6.0</TargetFramework>
+        <TargetFramework>$(NetStandardLibVersion)</TargetFramework>
         <PackageTags>$(AkkaPackageTags);Amazon;AWS;Kinesis</PackageTags>
     </PropertyGroup>
 

--- a/src/AWS/Kinesis/Akka.Streams.Kinesis/Akka.Streams.Kinesis.csproj
+++ b/src/AWS/Kinesis/Akka.Streams.Kinesis/Akka.Streams.Kinesis.csproj
@@ -4,12 +4,12 @@
     <PropertyGroup>
         <AssemblyTitle>Akka.Streams.Kinesis</AssemblyTitle>
         <Description>AWS Kinesis adapter for Akka.NET Streams</Description>
-        <TargetFramework>$(NetStandardLibVersion)</TargetFramework>
+        <TargetFramework>net6.0</TargetFramework>
         <PackageTags>$(AkkaPackageTags);Amazon;AWS;Kinesis</PackageTags>
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Akka.Streams" Version="$(AkkaVersion)" />
+        <PackageReference Include="Akka.Streams" Version="1.4.34" />
         <PackageReference Include="AWSSDK.Kinesis" Version="3.7.1.5" />
     </ItemGroup>
 </Project>

--- a/src/AWS/Kinesis/Akka.Streams.Kinesis/Akka.Streams.Kinesis.csproj
+++ b/src/AWS/Kinesis/Akka.Streams.Kinesis/Akka.Streams.Kinesis.csproj
@@ -9,7 +9,7 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Akka.Streams" Version="1.4.34" />
+        <PackageReference Include="Akka.Streams" Version="$(AkkaVersion)" />
         <PackageReference Include="AWSSDK.Kinesis" Version="3.7.1.5" />
     </ItemGroup>
 </Project>

--- a/src/AWS/Kinesis/Akka.Streams.Kinesis/KinesisSourceStage.cs
+++ b/src/AWS/Kinesis/Akka.Streams.Kinesis/KinesisSourceStage.cs
@@ -202,7 +202,7 @@ namespace Akka.Streams.Kinesis
 
             protected override void OnTimer(object timerKey)
             {
-                if ("GETRECORDS" == (string)timerKey)
+                if ("GET_RECORDS" == (string)timerKey)
                     RequestRecords(_self);
             }
         }

--- a/src/AWS/Kinesis/Akka.Streams.Kinesis/KinesisSourceStage.cs
+++ b/src/AWS/Kinesis/Akka.Streams.Kinesis/KinesisSourceStage.cs
@@ -80,6 +80,7 @@ namespace Akka.Streams.Kinesis
             private readonly Queue<Record> _buffer = new Queue<Record>();
             private StageActor _actor;
             private IActorRef _self;
+            private const string _timerKey = "GET_RECORDS";
 
             public Logic(KinesisSourceStage stage) : base(stage.Shape)
             {
@@ -172,7 +173,7 @@ namespace Akka.Streams.Kinesis
                         }
                         else
                         {
-                            ScheduleOnce("GET_RECORDS", _settings.RefreshInterval);
+                            ScheduleOnce(_timerKey, _settings.RefreshInterval);
                         }
                         break;
                     case GetRecordsFailure f:
@@ -202,7 +203,7 @@ namespace Akka.Streams.Kinesis
 
             protected override void OnTimer(object timerKey)
             {
-                if ("GET_RECORDS" == (string)timerKey)
+                if (_timerKey == (string)timerKey)
                     RequestRecords(_self);
             }
         }


### PR DESCRIPTION
## Changes

Fix typo with the `TimerKey` which was `GETRECORDS` instead of `GET_RECORDS` as a result after the first batch of messages are consumed, the timer fails to fetch the next batch of messages because, `RequestRecords(_self)` is never called for the second time!