### PR TITLE
Ported `DirectoryChangesSource` file module

### DIFF
--- a/docs/documentation/File.md
+++ b/docs/documentation/File.md
@@ -2,6 +2,27 @@
 
 The File connectors provide additional connectors for filesystems complementing the sources and sinks for files already included in core Akka Streams.
 
+## Listening to changes in a directory
+
+The `DirectoryChangesSource` will emit elements every time there is a change to a watched directory
+in the local filesystem, the emitted change consists of the path that was changed and an enumeration
+describing what kind of change it was.
+
+In this sample we simply print each change to the directory to standard output:
+
+```csharp
+const int maxBufferSize = 1000;
+var tempDir = Path.GetTempPath();
+
+DirectoryChangesSource.Create(tempDir, maxBufferSize)
+    .RunForeach(e =>
+    {
+        var (changedPath, change) = e;
+        Console.WriteLine($"Path: {changedPath}, Change: {change}");
+    }, _materializer);
+
+```
+
 ## Rotating the file to stream into 
 
 The `LogRotatorSink` will create and write to multiple files. This sink takes a creator as parameter which returns a `Func<ByteString, Option<string>>`. If the generated function returns a path the sink will rotate the file output to this new path and the actual `ByteString` will be written to this new file too. With this approach the user can define a custom stateful file generation implementation.

--- a/src/File/Akka.Streams.File.Tests/Akka.Streams.File.Tests.csproj
+++ b/src/File/Akka.Streams.File.Tests/Akka.Streams.File.Tests.csproj
@@ -3,6 +3,7 @@
 
   <PropertyGroup>
     <TargetFrameworks>$(NetCoreTestVersion)</TargetFrameworks>
+    <LangVersion>8.0</LangVersion>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 

--- a/src/File/Akka.Streams.File.Tests/DirectoryChangesSourceTest.cs
+++ b/src/File/Akka.Streams.File.Tests/DirectoryChangesSourceTest.cs
@@ -1,0 +1,127 @@
+﻿// -----------------------------------------------------------------------
+//  <copyright file="DirectoryChangesSourceSpec.cs" company="Akka.NET Project">
+//      Copyright (C) 2009-2022 Lightbend Inc. <http://www.lightbend.com>
+//      Copyright (C) 2013-2022 .NET Foundation <https://github.com/akkadotnet/akka.net>
+//  </copyright>
+// -----------------------------------------------------------------------
+
+using System.Collections.Generic;
+using System.IO;
+using System.Text;
+using Akka.Streams.Dsl;
+using Akka.Streams.File.Impl;
+using Akka.Streams.TestKit;
+using FluentAssertions;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Akka.Streams.File.Tests
+{
+    public class DirectoryChangesSourceSpec : Akka.TestKit.Xunit2.TestKit
+    {
+        private readonly ActorMaterializer _materializer;
+        private readonly string _tempDir;
+
+        public DirectoryChangesSourceSpec(ITestOutputHelper output)
+            : base(output: output)
+        {
+            _materializer = Sys.Materializer();
+            _tempDir = GetTmpDirectory();
+        }
+
+        [Fact]
+        public void DirectoryChangesSource_should_emit_on_directory_changes()
+        {
+            var probe = this.CreateSubscriberProbe<(string, DirectoryChange)>();
+
+            DirectoryChangesSource.Create(_tempDir, 200)
+                .RunWith(Sink.FromSubscriber(probe), _materializer);
+
+            probe.Request(1);
+
+            var createdFile = System.IO.File.Create(Path.Combine(_tempDir, "test1file1.sample"));
+            var pair1 = probe.ExpectNext();
+            pair1.Item2.Should().Be(DirectoryChange.Creation);
+            pair1.Item1.Should().Be(createdFile.Name);
+
+            // Flush to disk after writing, otherwise FileSystemWatcher won't pick up the changes
+            createdFile.Write(Encoding.UTF8.GetBytes("Some data"));
+            createdFile.Flush(flushToDisk: true);
+
+            var pair2 = probe.RequestNext();
+            pair2.Item2.Should().Be(DirectoryChange.Modification);
+            pair2.Item1.Should().Be(createdFile.Name);
+
+            // Close file before attempting to delete it
+            createdFile.Close();
+            System.IO.File.Delete(createdFile.Name);
+
+            // HACK: events can be raised more than once, see: https://github.com/dotnet/runtime/issues/24079
+            (string, DirectoryChange) pair3;
+            do
+            {
+                pair3 = probe.RequestNext();
+            } while (!(pair3.Item2 is DirectoryChange.Deletion));
+
+            pair3.Item2.Should().Be(DirectoryChange.Deletion);
+            pair3.Item1.Should().Be(createdFile.Name);
+
+            probe.Cancel();
+        }
+
+        [Fact]
+        public void DirectoryChangesSource_should_emit_multiple_changes()
+        {
+            const int numberOfChanges = 50;
+            var probe = this.CreateSubscriberProbe<(string, DirectoryChange)>();
+
+            DirectoryChangesSource.Create(_tempDir, numberOfChanges * 2)
+                .RunWith(Sink.FromSubscriber(probe), _materializer);
+
+            probe.Request(numberOfChanges);
+
+            var halfRequested = numberOfChanges / 2;
+            var files = new List<FileStream>();
+
+            for (var i = 0; i < halfRequested; i++)
+            {
+                var file = System.IO.File.Create(Path.Combine(_tempDir, "test2files" + i));
+                files.Add(file);
+            }
+
+            for (var i = 0; i < halfRequested; i++)
+                probe.ExpectNext();
+
+            for (var i = 0; i < halfRequested; i++)
+            {
+                var file = files[i];
+                file.Close();
+                System.IO.File.Delete(file.Name);
+            }
+
+            for (var i = 0; i < halfRequested; i++)
+                probe.ExpectNext();
+
+            probe.Cancel();
+        }
+
+        protected override void AfterAll()
+        {
+            Directory.Delete(_tempDir, true);
+            base.AfterAll();
+        }
+
+        private string GetTmpDirectory()
+        {
+            string tmpDirectory;
+
+            do
+            {
+                tmpDirectory = Path.Combine(Path.GetTempPath(), Path.GetFileNameWithoutExtension(Path.GetRandomFileName()));
+            } while (Directory.Exists(tmpDirectory));
+
+            Directory.CreateDirectory(tmpDirectory);
+            return tmpDirectory;
+        }
+    }
+}

--- a/src/File/Akka.Streams.File/DirectoryChangesSource.cs
+++ b/src/File/Akka.Streams.File/DirectoryChangesSource.cs
@@ -1,0 +1,26 @@
+﻿//-----------------------------------------------------------------------
+// <copyright file="DirectoryChangesSource.cs" company="Akka.NET Project">
+//     Copyright (C) 2009-2022 Lightbend Inc. <http://www.lightbend.com>
+//     Copyright (C) 2013-2022 .NET Foundation <https://github.com/akkadotnet/akka.net>
+// </copyright>
+//-----------------------------------------------------------------------
+
+using System;
+using Akka.Streams.Dsl;
+using Akka.Streams.File.Impl;
+
+namespace Akka.Streams.File
+{
+    public static class DirectoryChangesSource
+    {
+        private static readonly Func<string, DirectoryChange, (string, DirectoryChange)> _tupler = (t, u) => (t, u);
+
+        /// <summary>
+        /// Watch directory and emit changes as a stream of tuples containing the path and type of change.
+        /// </summary>
+        /// <param name="directoryPath">Directory to watch</param>
+        /// <param name="maxBufferSize">Maximum number of buffered directory changes before the stage fails</param>
+        public static Source<(string, DirectoryChange), NotUsed> Create(string directoryPath, int maxBufferSize) =>
+            Source.FromGraph(new DirectoryChangesSource<(string, DirectoryChange)>(directoryPath, maxBufferSize, _tupler));
+    }
+}

--- a/src/File/Akka.Streams.File/Impl/DirectoryChangesSource.cs
+++ b/src/File/Akka.Streams.File/Impl/DirectoryChangesSource.cs
@@ -1,0 +1,146 @@
+﻿//-----------------------------------------------------------------------
+// <copyright file="DirectoryChangesSource.cs" company="Akka.NET Project">
+//     Copyright (C) 2009-2022 Lightbend Inc. <http://www.lightbend.com>
+//     Copyright (C) 2013-2022 .NET Foundation <https://github.com/akkadotnet/akka.net>
+// </copyright>
+//-----------------------------------------------------------------------
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using Akka.Annotations;
+using Akka.Streams.Stage;
+
+namespace Akka.Streams.File.Impl
+{
+    /// <summary>
+    /// Watches a file system directory and streams change events from it.
+    /// </summary>
+    [InternalApi]
+    internal class DirectoryChangesSource<T> : GraphStage<SourceShape<T>>
+    {
+        private readonly string _directoryPath;
+        private readonly int _maxBufferSize;
+        private readonly Func<string, DirectoryChange, T> _combiner;
+
+        private Outlet<T> Out { get; } = new Outlet<T>("DirectoryChangesSource.Out");
+        public override SourceShape<T> Shape { get; }
+
+        /// <summary>
+        /// Creates an instance of the <see cref="DirectoryChangesSource{T}"/>.
+        /// </summary>
+        /// <param name="directoryPath">Directory to watch</param>
+        /// <param name="maxBufferSize">Maximum number of buffered directory changes before the stage fails</param>
+        /// <param name="combiner">A function that combines a string and a <see cref="DirectoryChange"/> into an element that will be emitted downstream</param>
+        public DirectoryChangesSource(string directoryPath, int maxBufferSize, Func<string, DirectoryChange, T> combiner)
+        {
+            _directoryPath = directoryPath;
+            _maxBufferSize = maxBufferSize;
+            _combiner = combiner;
+
+            Shape = new SourceShape<T>(Out);
+        }
+
+        protected override GraphStageLogic CreateLogic(Attributes inheritedAttributes)
+        {
+            if (!Directory.Exists(_directoryPath))
+                throw new DirectoryNotFoundException($"The path: '{_directoryPath}' does not exist or is not a directory");
+
+            return new DirectoryChangesSourceLogic(this);
+        }
+
+        #region Logic
+
+        private sealed class DirectoryChangesSourceLogic : OutGraphStageLogic
+        {
+            private readonly Queue<T> _buffer = new Queue<T>();
+            private readonly DirectoryChangesSource<T> _stage;
+            private readonly FileSystemWatcher _watcher;
+            private readonly Action<T> _onEventReceived;
+
+            public DirectoryChangesSourceLogic(DirectoryChangesSource<T> stage)
+                : base(stage.Shape)
+            {
+                _stage = stage;
+                _watcher = new FileSystemWatcher(stage._directoryPath, "*.*")
+                {
+                    IncludeSubdirectories = false,
+                    NotifyFilter = NotifyFilters.LastWrite | NotifyFilters.FileName | NotifyFilters.Size
+                };
+
+                _onEventReceived = GetAsyncCallback<T>(e =>
+                {
+                    if (IsAvailable(_stage.Out))
+                    {
+                        Push(_stage.Out, e);
+                        return;
+                    }
+
+                    _buffer.Enqueue(e);
+                    if (_buffer.Count > _stage._maxBufferSize)
+                        FailStage(new BufferOverflowException(
+                            $"Max event buffer size {_stage._maxBufferSize} reached for {_stage._directoryPath}"));
+                });
+
+                SetHandler(stage.Out, this);
+            }
+
+            public override void PreStart()
+            {
+                base.PreStart();
+
+                _watcher.Changed += EventReceived;
+                _watcher.Created += EventReceived;
+                _watcher.Deleted += EventReceived;
+                _watcher.Renamed += EventReceived;
+                _watcher.EnableRaisingEvents = true;
+            }
+
+            public override void PostStop()
+            {
+                _watcher.Changed -= EventReceived;
+                _watcher.Created -= EventReceived;
+                _watcher.Deleted -= EventReceived;
+                _watcher.Renamed += EventReceived;
+                _watcher.Dispose();
+
+                base.PostStop();
+            }
+
+            public override void OnPull()
+            {
+                if (_buffer.TryDequeue(out var head))
+                    Push(_stage.Out, head);
+            }
+
+            public override string ToString() => $"DirectoryChangesSource('{_stage._directoryPath}')";
+
+            private void EventReceived(object sender, FileSystemEventArgs args)
+            {
+                DirectoryChange KindToChange(WatcherChangeTypes changeType) => changeType switch
+                {
+                    WatcherChangeTypes.Created => DirectoryChange.Creation,
+                    WatcherChangeTypes.Renamed => DirectoryChange.Modification,
+                    WatcherChangeTypes.Changed => DirectoryChange.Modification,
+                    WatcherChangeTypes.Deleted => DirectoryChange.Deletion,
+                    _ => throw new ArgumentException($"Unexpected kind of event gotten from watching path '{_stage._directoryPath}': {changeType}")
+                };
+
+                var change = KindToChange(args.ChangeType);
+                _onEventReceived(_stage._combiner(args.FullPath, change));
+            }
+        }
+
+        #endregion
+    }
+
+    /// <summary>
+    /// Enumeration of the possible changes that can happen to a directory
+    /// </summary>
+    public enum DirectoryChange
+    {
+        Modification,
+        Creation,
+        Deletion
+    }
+}

--- a/src/File/Akka.Streams.File/Utils/QueueExtensions.cs
+++ b/src/File/Akka.Streams.File/Utils/QueueExtensions.cs
@@ -1,0 +1,17 @@
+﻿namespace System.Collections.Generic
+{
+    internal static class QueueExtensions
+    {
+        public static bool TryDequeue<T>(this Queue<T> queue, out T result)
+        {
+            if (queue.Count == 0)
+            {
+                result = default;
+                return false;
+            }
+
+            result = queue.Dequeue();
+            return true;
+        }
+    }
+}


### PR DESCRIPTION
> The `DirectoryChangesSource` will emit elements every time there is a change to a watched directory in the local filesystem, the emitted change consists of the path that was changed and an enumeration describing what kind of change it was.

This implementation is built on top the [FileSystemWatcher](https://docs.microsoft.com/en-us/dotnet/api/system.io.filesystemwatcher?view=netstandard-2.0).