### PR TITLE
Fixes `Option` usage in `LogRotatorSink`

### DIFF
--- a/src/File/Akka.Streams.File/LogRotatorSink.cs
+++ b/src/File/Akka.Streams.File/LogRotatorSink.cs
@@ -182,7 +182,7 @@ namespace Akka.Streams.File
             /// </summary>
             private void Rotate(TC triggerValue, T data)
             {
-                var prevOut = new Option<SubSourceOutlet<T>>(_sourceOut);
+                var prevOut = Option<SubSourceOutlet<T>>.Create(_sourceOut);
 
                 _sourceOut = new SubSourceOutlet<T>(this, "LogRotatorSink.Sub-Out");
                 _sourceOut.SetHandler(new LambdaOutHandler(onPull: () =>


### PR DESCRIPTION
Looks like `1.5.0` went live despite all the failing tests due to recent changes in the `Option` type API:

```
Cause: System.ArgumentNullException: You can not create an Option<T> with null value. Either use Option<T>.None or use Option<T>.Create(null). (Parameter 'value')
       at Akka.Util.Option`1..ctor(T value)
       at Akka.Streams.File.LogRotatorSink`3.LogRotatorSinkLogic.Rotate(TC triggerValue, T data) in D:\Projects\Github\alpakka.net\src\File\Akka.Streams.File\LogRotatorSink.cs:line 185
       at Akka.Streams.File.LogRotatorSink`3.LogRotatorSinkLogic.<>c__DisplayClass8_0.<.ctor>b__0() in D:\Projects\Github\alpakka.net\src\File\Akka.Streams.File\LogRotatorSink.cs:line 106
       at Akka.Streams.Stage.GraphStageLogic.LambdaInHandler.OnPush()
       at Akka.Streams.Implementation.Fusing.GraphInterpreter.Execute(Int32 eventLimit)
```