### PR TITLE
Fix new connection bug with SSL

### DIFF
--- a/src/Amqp/Akka.Streams.Amqp.RabbitMq/AmqpConnector.cs
+++ b/src/Amqp/Akka.Streams.Amqp.RabbitMq/AmqpConnector.cs
@@ -69,7 +69,7 @@ namespace Akka.Streams.Amqp.RabbitMq
                         throw new ArgumentException("You need to supply at least one host/port pair.", nameof(settings));
 
                     return factory.CreateConnection(details.HostAndPortList
-                        .Select(pair => new AmqpTcpEndpoint(pair.host, pair.port)).ToList());
+                        .Select(pair => new AmqpTcpEndpoint(pair.host, pair.port, details.Ssl)).ToList());
                 }
                 default:
                     return factory.CreateConnection();


### PR DESCRIPTION
Fixes #

`AmqpConnector` is currently unusable with SSL. The `NewConnection` method uses the `AmqpTcpEndpoint` constructor overload that accepts only a host name and port and creates a default `SslOption` instance (not enabled). This is problematic when the host is only configured for SSL.

![Screenshot 2023-06-23 at 8 36 09 PM](https://github.com/akkadotnet/Alpakka/assets/94796738/f15510f7-cf9f-4d2b-aaf4-fe29ba7e5661)

![Screenshot 2023-06-23 at 8 37 55 PM](https://github.com/akkadotnet/Alpakka/assets/94796738/6efb966a-c421-4b4d-b903-037a39883775)

## Changes

Pass in the existing `SslOption` setting from the config. Now it works as expected.

## Checklist

For significant changes, please ensure that the following have been completed (delete if not relevant):

* [x] I have [reviewed my own pull request](https://getakka.net/community/contributing/index.html#review-your-own-pull-requests).

### Latest `dev` Benchmarks 

Include data from the [relevant benchmark](https://getakka.net/community/contributing/index.html#improve-performance) prior to this change here.

### This PR's Benchmarks

Include data from after this change here.
