### PR TITLE
Fix bugged Dependabot version update for XUnit

### DIFF
--- a/src/Amqp/Akka.Streams.Amqp.RabbitMq.Tests/Akka.Streams.Amqp.RabbitMq.Tests.csproj
+++ b/src/Amqp/Akka.Streams.Amqp.RabbitMq.Tests/Akka.Streams.Amqp.RabbitMq.Tests.csproj
@@ -10,7 +10,7 @@
         <PackageReference Include="FluentAssertions" Version="$(FluentAssertionsVersion)" />
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="$(TestSdkVersion)" />
         <PackageReference Include="xunit" Version="$(XunitVersion)" />
-        <PackageReference Include="xunit.runner.visualstudio" Version="$(XunitVersion)" />
+        <PackageReference Include="xunit.runner.visualstudio" Version="$(XunitRunnerVersion)" />
         <PackageReference Include="coverlet.collector" Version="6.0.0" />
         <PackageReference Include="Docker.DotNet" Version="3.125.15" />
     </ItemGroup>

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -20,7 +20,7 @@
     <NetCoreTestVersion>netcoreapp3.1</NetCoreTestVersion>
     <NetTestVersion>net6.0</NetTestVersion>
     <NetFrameworkTestVersion>net471</NetFrameworkTestVersion>
-    <XunitVersion>2.5.6</XunitVersion>
+    <XunitVersion>2.5.3</XunitVersion>
     <XunitRunnerVersion>2.5.6</XunitRunnerVersion>
     <FluentAssertionsVersion>5.10.3</FluentAssertionsVersion>
     <TestSdkVersion>17.7.1</TestSdkVersion>


### PR DESCRIPTION
Fixes #1775

## Changes

In #1775, Dependabot was confused between `XunitVersion` and `XunitRunnerVersion` and applied a version upgrade for the xunit runner to both XML parameters. There are no XUnit version 2.5.6, moving it to 2.5.3 to match the version that is used in Akka.NET core.