### PR TITLE
adjusted namespaces on SignalR stages

### DIFF
--- a/src/SignalR/Akka.Streams.SignalR.Tests/Infrastructure/PublishSinkSource.cs
+++ b/src/SignalR/Akka.Streams.SignalR.Tests/Infrastructure/PublishSinkSource.cs
@@ -1,6 +1,6 @@
 ﻿using Akka.Streams.Dsl;
 
-namespace Akka.Streams.SignalR.AspNetCore.Tests.Infrastructure
+namespace Akka.Streams.SignalR.Tests.Infrastructure
 {
     public interface IPublishSinkSource
     {

--- a/src/SignalR/Akka.Streams.SignalR.Tests/Infrastructure/TestStreamHub.cs
+++ b/src/SignalR/Akka.Streams.SignalR.Tests/Infrastructure/TestStreamHub.cs
@@ -1,7 +1,7 @@
-﻿using Akka.Streams.SignalR.AspNetCore.Internals;
+﻿using Akka.Streams.SignalR.Internals;
 using Microsoft.AspNetCore.SignalR;
 
-namespace Akka.Streams.SignalR.AspNetCore.Tests.Infrastructure
+namespace Akka.Streams.SignalR.Tests.Infrastructure
 {
     /// <summary>
     /// Hubs rely on DI to get references.

--- a/src/SignalR/Akka.Streams.SignalR.Tests/Infrastructure/TestWebAppFactory.cs
+++ b/src/SignalR/Akka.Streams.SignalR.Tests/Infrastructure/TestWebAppFactory.cs
@@ -5,7 +5,7 @@ using Microsoft.AspNetCore.Mvc.Testing;
 using Microsoft.AspNetCore.TestHost;
 using Microsoft.Extensions.DependencyInjection;
 
-namespace Akka.Streams.SignalR.AspNetCore.Tests.Infrastructure
+namespace Akka.Streams.SignalR.Tests.Infrastructure
 {
     public class TestServerAppFactory : WebApplicationFactory<Startup>
     {

--- a/src/SignalR/Akka.Streams.SignalR.Tests/Infrastructure/WebApplicationFactoryExtensions.cs
+++ b/src/SignalR/Akka.Streams.SignalR.Tests/Infrastructure/WebApplicationFactoryExtensions.cs
@@ -1,7 +1,7 @@
 ﻿using Microsoft.AspNetCore.Mvc.Testing;
 using Microsoft.AspNetCore.SignalR.Client;
 
-namespace Akka.Streams.SignalR.AspNetCore.Tests.Infrastructure
+namespace Akka.Streams.SignalR.Tests.Infrastructure
 {
     public static class WebApplicationFactoryExtensions
     {

--- a/src/SignalR/Akka.Streams.SignalR.Tests/ServerIntegrationSpec.cs
+++ b/src/SignalR/Akka.Streams.SignalR.Tests/ServerIntegrationSpec.cs
@@ -2,7 +2,7 @@
 using System.Threading.Tasks;
 using Akka.Event;
 using Akka.Streams.Dsl;
-using Akka.Streams.SignalR.AspNetCore.Tests.Infrastructure;
+using Akka.Streams.SignalR.Tests.Infrastructure;
 using Akka.Streams.TestKit;
 using FluentAssertions;
 using Microsoft.AspNetCore.Builder;
@@ -13,7 +13,7 @@ using Microsoft.Extensions.DependencyInjection;
 using Xunit;
 using Xunit.Abstractions;
 
-namespace Akka.Streams.SignalR.AspNetCore.Tests
+namespace Akka.Streams.SignalR.Tests
 {
     public class ServerIntegrationSpec : 
         Akka.TestKit.Xunit2.TestKit, 

--- a/src/SignalR/Akka.Streams.SignalR/ConnectionSettings.cs
+++ b/src/SignalR/Akka.Streams.SignalR/ConnectionSettings.cs
@@ -1,9 +1,8 @@
 ﻿using System;
-using System.IO;
 using Akka.Actor;
 using Akka.Configuration;
 
-namespace Akka.Streams.SignalR.AspNetCore
+namespace Akka.Streams.SignalR
 {
     public sealed class ConnectionSinkSettings
     {

--- a/src/SignalR/Akka.Streams.SignalR/Events.cs
+++ b/src/SignalR/Akka.Streams.SignalR/Events.cs
@@ -1,7 +1,7 @@
-﻿using Microsoft.AspNetCore.SignalR;
-using System;
+﻿using System;
+using Microsoft.AspNetCore.SignalR;
 
-namespace Akka.Streams.SignalR.AspNetCore
+namespace Akka.Streams.SignalR
 {
     /// <summary>
     /// A common interface for all events incoming from SignalR socket.

--- a/src/SignalR/Akka.Streams.SignalR/IClientSink.cs
+++ b/src/SignalR/Akka.Streams.SignalR/IClientSink.cs
@@ -1,9 +1,6 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Text;
-using System.Threading.Tasks;
+﻿using System.Threading.Tasks;
 
-namespace Akka.Streams.SignalR.AspNetCore
+namespace Akka.Streams.SignalR
 {
     public interface IClientSink
     {

--- a/src/SignalR/Akka.Streams.SignalR/IServerSource.cs
+++ b/src/SignalR/Akka.Streams.SignalR/IServerSource.cs
@@ -1,9 +1,6 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Text;
-using System.Threading.Tasks;
+﻿using System.Threading.Tasks;
 
-namespace Akka.Streams.SignalR.AspNetCore
+namespace Akka.Streams.SignalR
 {
     public interface IServerSource
     {

--- a/src/SignalR/Akka.Streams.SignalR/Internals/DefaultStreamDispatcher.cs
+++ b/src/SignalR/Akka.Streams.SignalR/Internals/DefaultStreamDispatcher.cs
@@ -1,11 +1,9 @@
-﻿using Microsoft.AspNetCore.SignalR;
-using Microsoft.Extensions.DependencyInjection;
-using System;
+﻿using System;
 using System.Collections.Concurrent;
-using System.Collections.Generic;
-using System.Text;
+using Microsoft.AspNetCore.SignalR;
+using Microsoft.Extensions.DependencyInjection;
 
-namespace Akka.Streams.SignalR.AspNetCore.Internals
+namespace Akka.Streams.SignalR.Internals
 {
     public sealed class DefaultStreamDispatcher : IStreamDispatcher
     {

--- a/src/SignalR/Akka.Streams.SignalR/Internals/IStreamDispatcher.cs
+++ b/src/SignalR/Akka.Streams.SignalR/Internals/IStreamDispatcher.cs
@@ -1,6 +1,6 @@
 ﻿using System;
 
-namespace Akka.Streams.SignalR.AspNetCore.Internals
+namespace Akka.Streams.SignalR.Internals
 {
     public interface IStreamDispatcher
     {

--- a/src/SignalR/Akka.Streams.SignalR/Internals/SignalRSinkStage.cs
+++ b/src/SignalR/Akka.Streams.SignalR/Internals/SignalRSinkStage.cs
@@ -1,11 +1,9 @@
 ﻿using System;
 using System.Linq;
-using System.Threading.Tasks;
 using Akka.Streams.Stage;
 using Microsoft.AspNetCore.SignalR;
-using AsyncCallback = Akka.Streams.Stage.AsyncCallback;
 
-namespace Akka.Streams.SignalR.AspNetCore.Internals
+namespace Akka.Streams.SignalR.Internals
 {
     internal sealed class SignalRSinkStage : GraphStage<SinkShape<ISignalRResult>>
     {

--- a/src/SignalR/Akka.Streams.SignalR/Internals/SignalRSourceStage.cs
+++ b/src/SignalR/Akka.Streams.SignalR/Internals/SignalRSourceStage.cs
@@ -1,9 +1,8 @@
 ﻿using System;
 using System.Collections.Generic;
 using Akka.Streams.Stage;
-using Microsoft.AspNetCore.SignalR;
 
-namespace Akka.Streams.SignalR.AspNetCore.Internals
+namespace Akka.Streams.SignalR.Internals
 {
     internal sealed class SignalRSourceStage : GraphStage<SourceShape<ISignalREvent>>
     {

--- a/src/SignalR/Akka.Streams.SignalR/Messages.cs
+++ b/src/SignalR/Akka.Streams.SignalR/Messages.cs
@@ -1,7 +1,7 @@
-﻿using System.Collections.Generic;
 ﻿using System;
+using System.Collections.Generic;
 
-namespace Akka.Streams.SignalR.AspNetCore
+namespace Akka.Streams.SignalR
 {
     /// <summary>
     /// A common static class for building messages returned to SignalR clients.

--- a/src/SignalR/Akka.Streams.SignalR/ServicesExtensions.cs
+++ b/src/SignalR/Akka.Streams.SignalR/ServicesExtensions.cs
@@ -1,10 +1,7 @@
-﻿using Akka.Streams.SignalR.AspNetCore;
-using Akka.Streams.SignalR.AspNetCore.Internals;
-using System;
-using System.Collections.Generic;
-using System.Text;
+﻿using Akka.Streams.SignalR.Internals;
+using Microsoft.Extensions.DependencyInjection;
 
-namespace Microsoft.Extensions.DependencyInjection
+namespace Akka.Streams.SignalR
 {
     public static class AkkaSignalRDependencyInjectionExtensions
     {

--- a/src/SignalR/Akka.Streams.SignalR/StreamConnector.cs
+++ b/src/SignalR/Akka.Streams.SignalR/StreamConnector.cs
@@ -1,13 +1,9 @@
 ﻿using System;
-using System.Collections.Concurrent;
-using System.Threading.Tasks;
 using Akka.Streams.Dsl;
-using Akka.Streams.SignalR.AspNetCore.Internals;
-using Microsoft.AspNetCore.Http;
+using Akka.Streams.SignalR.Internals;
 using Microsoft.AspNetCore.SignalR;
-using Microsoft.Extensions.DependencyInjection;
 
-namespace Akka.Streams.SignalR.AspNetCore
+namespace Akka.Streams.SignalR
 {
     /// <summary>
     /// Inherit to connect processing stages to Source to receive incoming SignalR client messages, 

--- a/src/SignalR/Akka.Streams.SignalR/StreamHub.cs
+++ b/src/SignalR/Akka.Streams.SignalR/StreamHub.cs
@@ -1,9 +1,9 @@
 ﻿using System;
 using System.Threading.Tasks;
-using Akka.Streams.SignalR.AspNetCore.Internals;
+using Akka.Streams.SignalR.Internals;
 using Microsoft.AspNetCore.SignalR;
 
-namespace Akka.Streams.SignalR.AspNetCore
+namespace Akka.Streams.SignalR
 {
     /// <summary>
     /// A variant of <see cref="Hub"/> able to cooperate with Akka.Streams API.


### PR DESCRIPTION
## Changes

Removed all of the `.AspNetCore` cruft.