### PR TITLE
Minor read-side RabbitMQ perf optimization

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -204,3 +204,4 @@ build/
 .nuget/
 .dotnet/
 .idea
+/src/Amqp/Akka.Streams.RabbitMq.Amqp.Benchmarks/BenchmarkDotNet.Artifacts

--- a/src/Amqp/Akka.Streams.Amqp.RabbitMq/Envelope.cs
+++ b/src/Amqp/Akka.Streams.Amqp.RabbitMq/Envelope.cs
@@ -4,7 +4,7 @@ namespace Akka.Streams.Amqp.RabbitMq
     /// <summary>
     /// Encapsulates a group of parameters used for AMQP's Basic methods
     /// </summary>
-    public sealed class Envelope
+    public readonly struct Envelope
     {
         /// <summary>
         /// Get the delivery tag included in this parameter envelope

--- a/src/Amqp/Akka.Streams.Amqp.RabbitMq/IncomingMessage.cs
+++ b/src/Amqp/Akka.Streams.Amqp.RabbitMq/IncomingMessage.cs
@@ -5,7 +5,7 @@ namespace Akka.Streams.Amqp.RabbitMq
 {
     public sealed class IncomingMessage
     {
-        public IncomingMessage(ByteString bytes, Envelope envelope, IBasicProperties properties)
+        public IncomingMessage(ByteString bytes, in Envelope envelope, IBasicProperties properties)
         {
             Bytes = bytes;
             Envelope = envelope;


### PR DESCRIPTION
## Changes

The BIG improvements will come from making `ByteString` less bad inside Akka.NET, as there is a TON of memory copying that is unecessary right now.

## Checklist

For significant changes, please ensure that the following have been completed (delete if not relevant):

* [x] This change follows the [Akka.NET API Compatibility Guidelines](https://getakka.net/community/contributing/api-changes-compatibility.html).
* [x] This change follows the [Akka.NET Wire Compatibility Guidelines](https://getakka.net/community/contributing/wire-compatibility.html).
* [x] I have [reviewed my own pull request](https://getakka.net/community/contributing/index.html#review-your-own-pull-requests).

### Latest `dev` Benchmarks 

```
BenchmarkDotNet v0.13.12, Windows 11 (10.0.22631.3296/23H2/2023Update/SunValley3)
12th Gen Intel Core i7-1260P, 1 CPU, 16 logical and 12 physical cores
.NET SDK 8.0.101
  [Host]     : .NET 6.0.26 (6.0.2623.60508), X64 RyuJIT AVX2
  Job-WOEZAU : .NET 6.0.26 (6.0.2623.60508), X64 RyuJIT AVX2

InvocationCount=1  IterationCount=10  RunStrategy=ColdStart  
UnrollFactor=1  WarmupCount=0  

```
| Method           | Mean     | Error    | StdDev   | Gen0   | Allocated |
|----------------- |---------:|---------:|---------:|-------:|----------:|
| RabbitMqReadFlow | 87.19 μs | 5.047 μs | 3.338 μs | 0.1700 |   1.56 KB |

### This PR's Benchmarks

```

BenchmarkDotNet v0.13.12, Windows 11 (10.0.22631.3296/23H2/2023Update/SunValley3)
12th Gen Intel Core i7-1260P, 1 CPU, 16 logical and 12 physical cores
.NET SDK 8.0.101
  [Host]     : .NET 6.0.26 (6.0.2623.60508), X64 RyuJIT AVX2
  Job-NDZWOM : .NET 6.0.26 (6.0.2623.60508), X64 RyuJIT AVX2

InvocationCount=1  IterationCount=10  RunStrategy=ColdStart  
UnrollFactor=1  WarmupCount=0  

```
| Method           | Mean     | Error    | StdDev   | Gen0   | Allocated |
|----------------- |---------:|---------:|---------:|-------:|----------:|
| RabbitMqReadFlow | 104.7 μs | 28.80 μs | 19.05 μs | 0.1600 |   1.53 KB |


Ignore the mean perf number - I was focused solely on memory allocs here and was doing a ton of other work in the background. Those numbers are not reliable.
