### PR TITLE
added v1.5.18 release notes

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,30 +1,5 @@
-#### 1.5.15 January 11 2024 ####
-* Bumped to [Akka.NET v1.5.15](https://github.com/akkadotnet/akka.net/releases/tag/1.5.15)
-* Bump all dependency versions
-  * [Bump AWSSDK.SQS to 3.7.300.33](https://github.com/akkadotnet/Alpakka/pull/1734)
-  * [Bump AWSSDK.Kinesis to 3.7.301.26](https://github.com/akkadotnet/Alpakka/pull/1785)
-  * [Bump AWSSDK.SimpleNotificationService to 3.7.300.33](https://github.com/akkadotnet/Alpakka/pull/1786)
-  * [Bump Microsoft.AspNetCore.SignalR.Client to 7.0.11](https://github.com/akkadotnet/Alpakka/pull/1663)
-  * [Bump Azure.Storage.Queues to 12.17.1](https://github.com/akkadotnet/Alpakka/pull/1778)
-  * [Bump Azure.Messaging.ServiceBus to 7.17.1](https://github.com/akkadotnet/Alpakka/pull/1772)
-  * [Bump Azure.Messaging.EventHubs.Processor to 5.10.0](https://github.com/akkadotnet/Alpakka/pull/1757)
-  * [Bump AMQPNetLite.Core to 2.4.8](https://github.com/akkadotnet/Alpakka/pull/1774)
-  * [Bump AMQPNetLite.Serialization to 2.4.8](https://github.com/akkadotnet/Alpakka/pull/1774)
-
-#### 1.5.8 June 08 2023 ####
-* Bumped to [Akka.NET v1.5.8](https://github.com/akkadotnet/akka.net/releases/tag/1.5.8)
-* [[AMPQ] Pass SSL options into AmqpTcpEndpoint](https://github.com/akkadotnet/Alpakka/pull/1612)
-* Bump all dependency versions
-  * [Bump AWSSDK.Kinesis to 3.7.102.74](https://github.com/akkadotnet/Alpakka/pull/1591)
-  * [Bump AWSSDK.SimpleNotificationService to 3.7.101.76](https://github.com/akkadotnet/Alpakka/pull/1597)
-  * [Bump Azure.Storage.Queue to 12.14.0](https://github.com/akkadotnet/Alpakka/pull/1593)
-  * [Bump Azure.Messaging.EventHubs.Processor to 5.9.2](https://github.com/akkadotnet/Alpakka/pull/1600)
-  * [Bump Azure.Messaging.ServiceBus to 7.15.0](https://github.com/akkadotnet/Alpakka/pull/1615)
-
-#### 1.5.7 May 31 2023 ####
-
-* Bumped to [Akka.NET v1.5.7](https://github.com/akkadotnet/akka.net/releases/tag/1.5.7)
-
-#### 1.0.1-beta4 October 21 2022 ####
-* Upgraded to [Akka.NET v1.4.45](https://github.com/akkadotnet/akka.net/releases/tag/1.4.45)
-* Upgraded all SDK versions
+#### 1.5.18 March 27 2024 ####
+* Bumped to [Akka.NET v1.5.18](https://github.com/akkadotnet/akka.net/releases/tag/1.5.18)
+* [Akka.Streams.Ampq.RabbitMq: NullReferenceException - when using Akka.Net v1.5.12 and Akka.Streams.Amqp.RabbitMq v1.5.8](https://github.com/akkadotnet/Alpakka/issues/1659)
+* [Akka.Streams.Ampq.RabbitMq: added publisher confirms functionality to RabbitMQ](https://github.com/akkadotnet/Alpakka/pull/1906)
+* Merged Akka.Streams.SignalR and Akka.Streams.SignalR.AspNetCore; dropped all non-ASP.NET Core functionality. Will issue a package deprecation warning for Akka.Streams.SignalR.AspNetCore.

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <Copyright>Copyright © 2013-2023 Akka.NET Team</Copyright>
     <Authors>Akka.NET Team</Authors>
-    <VersionPrefix>1.5.15</VersionPrefix>
+    <VersionPrefix>1.5.18</VersionPrefix>
     <PackageIconUrl>http://getakka.net/images/akkalogo.png</PackageIconUrl>
     <PackageProjectUrl>https://github.com/akkadotnet/Alpakka</PackageProjectUrl>
     <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>
@@ -35,17 +35,10 @@
     <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
   </PropertyGroup>
   <PropertyGroup>
-    <PackageReleaseNotes>Bumped to [Akka.NET v1.5.15](https://github.com/akkadotnet/akka.net/releases/tag/1.5.15)
-Bump all dependency versions
-[Bump AWSSDK.SQS to 3.7.300.33](https://github.com/akkadotnet/Alpakka/pull/1734)
-[Bump AWSSDK.Kinesis to 3.7.301.26](https://github.com/akkadotnet/Alpakka/pull/1785)
-[Bump AWSSDK.SimpleNotificationService to 3.7.300.33](https://github.com/akkadotnet/Alpakka/pull/1786)
-[Bump Microsoft.AspNetCore.SignalR.Client to 7.0.11](https://github.com/akkadotnet/Alpakka/pull/1663)
-[Bump Azure.Storage.Queues to 12.17.1](https://github.com/akkadotnet/Alpakka/pull/1778)
-[Bump Azure.Messaging.ServiceBus to 7.17.1](https://github.com/akkadotnet/Alpakka/pull/1772)
-[Bump Azure.Messaging.EventHubs.Processor to 5.10.0](https://github.com/akkadotnet/Alpakka/pull/1757)
-[Bump AMQPNetLite.Core to 2.4.8](https://github.com/akkadotnet/Alpakka/pull/1774)
-[Bump AMQPNetLite.Serialization to 2.4.8](https://github.com/akkadotnet/Alpakka/pull/1774)</PackageReleaseNotes>
+    <PackageReleaseNotes>Bumped to [Akka.NET v1.5.18](https://github.com/akkadotnet/akka.net/releases/tag/1.5.18)
+[Akka.Streams.Ampq.RabbitMq: NullReferenceException - when using Akka.Net v1.5.12 and Akka.Streams.Amqp.RabbitMq v1.5.8](https://github.com/akkadotnet/Alpakka/issues/1659)
+[Akka.Streams.Ampq.RabbitMq: added publisher confirms functionality to RabbitMQ](https://github.com/akkadotnet/Alpakka/pull/1906)
+Merged Akka.Streams.SignalR and Akka.Streams.SignalR.AspNetCore; dropped all non-ASP.NET Core functionality. Will issue a package deprecation warning for Akka.Streams.SignalR.AspNetCore.</PackageReleaseNotes>
   </PropertyGroup>
   <!-- SourceLink support for all Akka.NET projects -->
   <ItemGroup>


### PR DESCRIPTION
#### 1.5.18 March 27 2024 ####
* Bumped to [Akka.NET v1.5.18](https://github.com/akkadotnet/akka.net/releases/tag/1.5.18)
* [Akka.Streams.Ampq.RabbitMq: NullReferenceException - when using Akka.Net v1.5.12 and Akka.Streams.Amqp.RabbitMq v1.5.8](https://github.com/akkadotnet/Alpakka/issues/1659)
* [Akka.Streams.Ampq.RabbitMq: added publisher confirms functionality to RabbitMQ](https://github.com/akkadotnet/Alpakka/pull/1906)
* Merged Akka.Streams.SignalR and Akka.Streams.SignalR.AspNetCore; dropped all non-ASP.NET Core functionality. Will issue a package deprecation warning for Akka.Streams.SignalR.AspNetCore.