### PR TITLE
Update RELEASE_NOTES.,md for 1.5.28 release

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,5 +1,11 @@
-#### 1.5.18 March 27 2024 ####
-* Bumped to [Akka.NET v1.5.18](https://github.com/akkadotnet/akka.net/releases/tag/1.5.18)
-* [Akka.Streams.Ampq.RabbitMq: NullReferenceException - when using Akka.Net v1.5.12 and Akka.Streams.Amqp.RabbitMq v1.5.8](https://github.com/akkadotnet/Alpakka/issues/1659)
-* [Akka.Streams.Ampq.RabbitMq: added publisher confirms functionality to RabbitMQ](https://github.com/akkadotnet/Alpakka/pull/1906)
-* Merged Akka.Streams.SignalR and Akka.Streams.SignalR.AspNetCore; dropped all non-ASP.NET Core functionality. Will issue a package deprecation warning for Akka.Streams.SignalR.AspNetCore.
+#### 1.5.28 September 9 2024 ####
+
+* Bumped to [Akka.NET v1.5.28](https://github.com/akkadotnet/akka.net/releases/tag/1.5.28)
+* [EventHub.V5: Fix concurrent processor event bug](https://github.com/akkadotnet/Alpakka/pull/1972)
+* Bump all dependency versions
+  * [Bump AWSSDK.SQS to 3.7.300.70](https://github.com/akkadotnet/Alpakka/pull/1934)
+  * [Bump AWSSDK.Kinesis to 3.7.301.86](https://github.com/akkadotnet/Alpakka/pull/1960)
+  * [Bump AWSSDK.SimpleNotificationService](https://github.com/akkadotnet/Alpakka/pull/1961)
+  * [Bump AWSSDK.SQS to 3.7.301.6](https://github.com/akkadotnet/Alpakka/pull/1962)
+  * [Bump Azure.Storage.Queues to 12.18.0](https://github.com/akkadotnet/Alpakka/pull/1953)
+  * [Bump Azure.Messaging.EventHubs.Processor to 5.11.3](https://github.com/akkadotnet/Alpakka/pull/1956)


### PR DESCRIPTION
## 1.5.28 September 9 2024

* Bumped to [Akka.NET v1.5.28](https://github.com/akkadotnet/akka.net/releases/tag/1.5.28)
* [EventHub.V5: Fix concurrent processor event bug](https://github.com/akkadotnet/Alpakka/pull/1972)
* Bump all dependency versions
  * [Bump AWSSDK.SQS to 3.7.300.70](https://github.com/akkadotnet/Alpakka/pull/1934)
  * [Bump AWSSDK.Kinesis to 3.7.301.86](https://github.com/akkadotnet/Alpakka/pull/1960)
  * [Bump AWSSDK.SimpleNotificationService](https://github.com/akkadotnet/Alpakka/pull/1961)
  * [Bump AWSSDK.SQS to 3.7.301.6](https://github.com/akkadotnet/Alpakka/pull/1962)
  * [Bump Azure.Storage.Queues to 12.18.0](https://github.com/akkadotnet/Alpakka/pull/1953)
  * [Bump Azure.Messaging.EventHubs.Processor to 5.11.3](https://github.com/akkadotnet/Alpakka/pull/1956)
