### PR TITLE
Update RELEASE_NOTES.md for 1.5.33 release

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,11 +1,4 @@
-#### 1.5.28 September 9 2024 ####
+#### 1.5.33 December 23rd 2024 ####
 
-* Bumped to [Akka.NET v1.5.28](https://github.com/akkadotnet/akka.net/releases/tag/1.5.28)
-* [EventHub.V5: Fix concurrent processor event bug](https://github.com/akkadotnet/Alpakka/pull/1972)
-* Bump all dependency versions
-  * [Bump AWSSDK.SQS to 3.7.300.70](https://github.com/akkadotnet/Alpakka/pull/1934)
-  * [Bump AWSSDK.Kinesis to 3.7.301.86](https://github.com/akkadotnet/Alpakka/pull/1960)
-  * [Bump AWSSDK.SimpleNotificationService](https://github.com/akkadotnet/Alpakka/pull/1961)
-  * [Bump AWSSDK.SQS to 3.7.301.6](https://github.com/akkadotnet/Alpakka/pull/1962)
-  * [Bump Azure.Storage.Queues to 12.18.0](https://github.com/akkadotnet/Alpakka/pull/1953)
-  * [Bump Azure.Messaging.EventHubs.Processor to 5.11.3](https://github.com/akkadotnet/Alpakka/pull/1956)
+* Bumped to [Akka.NET v1.5.33](https://github.com/akkadotnet/akka.net/releases/tag/1.5.33)
+* [EventHub: Deprecated Akka.Streams.Azure.EventHub.V5](https://github.com/akkadotnet/Alpakka/pull/1974)


### PR DESCRIPTION
## 1.5.33 December 23rd 2024

* Bumped to [Akka.NET v1.5.33](https://github.com/akkadotnet/akka.net/releases/tag/1.5.33)
* [EventHub: Deprecated Akka.Streams.Azure.EventHub.V5](https://github.com/akkadotnet/Alpakka/pull/1974)
