### PR TITLE
Release 1.5.57

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <Copyright>Copyright © 2013-$([System.DateTime]::Now.Year) Akka.NET Team</Copyright>
     <Authors>Akka.NET Team</Authors>
-    <VersionPrefix>1.5.40</VersionPrefix>
+    <VersionPrefix>1.5.57</VersionPrefix>
     <PackageIconUrl>http://getakka.net/images/akkalogo.png</PackageIconUrl>
     <PackageProjectUrl>https://github.com/akkadotnet/Alpakka</PackageProjectUrl>
     <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>
@@ -22,9 +22,7 @@
     <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
   </PropertyGroup>
   <PropertyGroup>
-    <PackageReleaseNotes>* Bumped to [Akka.NET v1.5.40](https://github.com/akkadotnet/akka.net/releases/tag/1.5.40)
-* Resolved: [Akka.Streams.Azure.EventHubs: Source no longer emits empty event](https://github.com/akkadotnet/Alpakka/issues/1979)
-* Akka.Streams.SignalR: migrated away from [`Microsoft.AspNetCore.App`](https://www.nuget.org/packages/Microsoft.AspNetCore.App/), which was for `netcoreapp3.1` and earlier, to [`Microsoft.AspNetCore.SignalR`](https://www.nuget.org/packages/Microsoft.AspNetCore.SignalR), which supports all newer versions of ASP.NET Core and SignalR.</PackageReleaseNotes>
+    <PackageReleaseNotes>* Bumped to [Akka.NET v1.5.57](https://github.com/akkadotnet/akka.net/releases/tag/1.5.57)</PackageReleaseNotes>
   </PropertyGroup>
   <!-- SourceLink support for all Akka.NET projects -->
   <ItemGroup>

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,3 +1,7 @@
+#### 1.5.57 December 23rd 2025 ####
+
+* Bumped to [Akka.NET v1.5.57](https://github.com/akkadotnet/akka.net/releases/tag/1.5.57)
+
 #### 1.5.40 April 18th 2025 ####
 
 * Bumped to [Akka.NET v1.5.40](https://github.com/akkadotnet/akka.net/releases/tag/1.5.40)


### PR DESCRIPTION
## Summary
- Updated version to 1.5.57
- Bumped Akka.NET dependency to v1.5.57
- Updated release notes

## Changes
- Updated `Directory.Build.props` with new version
- Updated `RELEASE_NOTES.md` with release entry for December 23rd 2025