### PR TITLE
Add IsPackable=false to Aspire example projects

### DIFF
--- a/src/Azure/Examples/Simple/EventHub/EventHub.AppHost/EventHub.AppHost.csproj
+++ b/src/Azure/Examples/Simple/EventHub/EventHub.AppHost/EventHub.AppHost.csproj
@@ -7,6 +7,7 @@
     <TargetFramework>$(NetTestVersion)</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
     <UserSecretsId>1d14029f-a74d-460f-bfe0-80cc7e8c27a9</UserSecretsId>
   </PropertyGroup>
 

--- a/src/Azure/Examples/Simple/EventHub/EventHub.Consumer/EventHub.Consumer.csproj
+++ b/src/Azure/Examples/Simple/EventHub/EventHub.Consumer/EventHub.Consumer.csproj
@@ -5,6 +5,7 @@
     <TargetFramework>$(NetTestVersion)</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Azure/Examples/Simple/EventHub/EventHub.Producer/EventHub.Producer.csproj
+++ b/src/Azure/Examples/Simple/EventHub/EventHub.Producer/EventHub.Producer.csproj
@@ -5,6 +5,7 @@
     <TargetFramework>$(NetTestVersion)</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Azure/Examples/Simple/ServiceBus/ServiceBus.AppHost/ServiceBus.AppHost.csproj
+++ b/src/Azure/Examples/Simple/ServiceBus/ServiceBus.AppHost/ServiceBus.AppHost.csproj
@@ -7,6 +7,7 @@
     <TargetFramework>$(NetTestVersion)</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
     <UserSecretsId>b366642b-c8ff-4c01-95f6-5ae66759e333</UserSecretsId>
   </PropertyGroup>
 

--- a/src/Azure/Examples/Simple/ServiceBus/ServiceBusConsumer/ServiceBusConsumer.csproj
+++ b/src/Azure/Examples/Simple/ServiceBus/ServiceBusConsumer/ServiceBusConsumer.csproj
@@ -5,6 +5,7 @@
     <TargetFramework>$(NetTestVersion)</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Azure/Examples/Simple/ServiceBus/ServiceBusProducer/ServiceBusProducer.csproj
+++ b/src/Azure/Examples/Simple/ServiceBus/ServiceBusProducer/ServiceBusProducer.csproj
@@ -5,6 +5,7 @@
     <TargetFramework>$(NetTestVersion)</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
## Summary
- Add `IsPackable=false` to all Aspire example projects to prevent them from being packed and pushed to NuGet during release builds

## Affected projects
- EventHub.Consumer
- EventHub.Producer
- EventHub.AppHost
- ServiceBusConsumer
- ServiceBusProducer
- ServiceBus.AppHost