### PR TITLE
feat: bump to Akka.NET v1.5.68

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <Copyright>Copyright © 2013-$([System.DateTime]::Now.Year) Akka.NET Team</Copyright>
     <Authors>Akka.NET Team</Authors>
-    <VersionPrefix>1.5.59</VersionPrefix>
+    <VersionPrefix>1.5.68</VersionPrefix>
     <PackageIconUrl>http://getakka.net/images/akkalogo.png</PackageIconUrl>
     <PackageProjectUrl>https://github.com/akkadotnet/Alpakka</PackageProjectUrl>
     <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>
@@ -22,7 +22,7 @@
     <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
   </PropertyGroup>
   <PropertyGroup>
-    <PackageReleaseNotes>* Bumped to [Akka.NET v1.5.59](https://github.com/akkadotnet/akka.net/releases/tag/1.5.59)</PackageReleaseNotes>
+    <PackageReleaseNotes>* Bumped to [Akka.NET v1.5.68](https://github.com/akkadotnet/akka.net/releases/tag/1.5.68)</PackageReleaseNotes>
   </PropertyGroup>
   <!-- SourceLink support for all Akka.NET projects -->
   <ItemGroup>

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -4,7 +4,7 @@
     <AspireVersion>13.0.0</AspireVersion>
   </PropertyGroup>
   <PropertyGroup Label="SharedVersions">
-    <AkkaVersion>1.5.60</AkkaVersion>
+    <AkkaVersion>1.5.68</AkkaVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageVersion Include="Aspire.Azure.Messaging.EventHubs" Version="13.0.2" />


### PR DESCRIPTION
## Changes
- Bumped Akka.NET dependency from 1.5.60 to 1.5.68
- Updated VersionPrefix from 1.5.59 to 1.5.68
- Updated release notes

## Motivation
Alpakka was significantly behind Akka.NET (1.5.60 vs 1.5.68). This brings it up to date and aligns with the OTEL trace context propagation changes from #8160.

## CI
Please monitor CI for any build issues.
